### PR TITLE
[DRAFT] Drive seed generation from JSON, support custom presets

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+    "env": {
+        "browser": true,
+        "es2021": true,
+        "jquery": true
+    },
+    "extends": [
+      "eslint:recommended"
+    ],
+    "parserOptions": {
+        "ecmaVersion": "latest"
+    },
+    "rules": {
+    },
+    "ignorePatterns": [
+      "generator/static/tracker/**/*.js",
+      "node_modules/**/*.js"
+    ]
+}

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,19 @@
+[flake8]
+exclude = .git,__pycache__,jetsoftime
+max-line-length = 119
+
+extend-ignore=
+  # Ignore formatting issues that a tool like black could automatically address
+  ## non-syntax indentation (visual)
+  # E122, E123, E128, E131,
+
+  ## whitespace with comments
+  E261, E262, E265,
+
+  # Ignore other issues which may or may not care about
+  ## module level import not at top of file
+  ## this is because of sys.path adding jetsoftime submodule
+  E402,
+
+  ## ambigious variable name
+  E741

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,__pycache__,jetsoftime
+exclude = .git,__pycache__,jetsoftime,node_modules
 max-line-length = 119
 
 extend-ignore=

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -1,0 +1,22 @@
+---
+name: Run ESLint
+
+on:
+  push:
+    paths:
+      - .github/workflows/eslint.yaml
+      - '**.js'
+      - .eslint*
+      - packages.json
+
+jobs:
+  build:
+    name: Run ESLint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm install
+      - uses: eslint/github-action@v0

--- a/.github/workflows/flake-pytest.yaml
+++ b/.github/workflows/flake-pytest.yaml
@@ -1,0 +1,25 @@
+name: Python lint and test
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test-requirements.txt
+      - name: Lint with flake8
+        run: |
+          flake8 . --show-source --statistics -v

--- a/.github/workflows/flake-pytest.yaml
+++ b/.github/workflows/flake-pytest.yaml
@@ -1,6 +1,15 @@
 name: Python lint and test
 
-on: [push]
+on:
+  push:
+    paths:
+      - .github/workflows/flake-pytest.yaml
+      - '**.py'
+      - .flake8
+      - jetsoftime
+      - pyproject.toml
+      - requirements.txt
+      - test-requirements.txt
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ patches
 pickles
 names.txt
 patch.ips
+node_modules
+package-lock.json

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,13 @@
+asgiref==3.7.2
+Django==4.1.11
+django-cors-headers==3.14.0
+gunicorn==21.2.0
+nanoid==2.0.0
+Pillow==9.5.0
+psycopg2-binary==2.9.7
+referencing==0.30.2
+sqlparse==0.4.4
+tzdata==2023.3
+
+# constraints for requirements for testing
+flake8>=6.1,<7.0

--- a/ctjot/settings.py
+++ b/ctjot/settings.py
@@ -30,7 +30,7 @@ DEBUG = int(os.environ.get("DEBUG", "0"))
 if os.environ.get("DJANGO_ALLOWED_HOSTS") is None:
     ALLOWED_HOSTS = ['localhost', '127.0.0.1']
 else:
-    ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS").split(" ")
+    ALLOWED_HOSTS = os.environ.get("DJANGO_ALLOWED_HOSTS", "").split(" ")
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 

--- a/ctjot/settings.py
+++ b/ctjot/settings.py
@@ -142,4 +142,4 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_METHODS = ["GET", "OPTIONS"]
-CORS_URLS_REGEX = r"^/spoiler_log/.*\.json$"
+CORS_URLS_REGEX = r"^/download/.*\.json$"

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -3,7 +3,7 @@
 ###########
 
 # pull official base image
-FROM python:3.10.6-alpine as builder
+FROM python:3.11.5-alpine as builder
 
 # set work directory
 WORKDIR /usr/src/app
@@ -27,7 +27,7 @@ RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requir
 #########
 
 # pull official base image
-FROM python:3.10.6-alpine
+FROM python:3.11.5-alpine
 
 # Set up a user for the webapp
 RUN mkdir -p /home/ctjot

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -17,6 +17,7 @@ RUN apk update \
     && apk add postgresql-dev gcc python3-dev musl-dev
 
 # install dependencies
+COPY ./constraints.txt .
 COPY ./requirements.txt .
 RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requirements.txt
 
@@ -47,15 +48,6 @@ RUN pip install --no-cache /wheels/*
 # Copy the web generator repo files into the container
 COPY . $APP_HOME
 RUN chmod +x $APP_HOME/deploy/entrypoint.sh
-
-# Create links needed by the web generator
-# The randomizer looks for these off of the app's running directory
-# so they need to be linked to the web app's basedir.
-RUN ln -s $APP_HOME/jetsoftime/sourcefiles/names.txt $APP_HOME/names.txt && \
-    ln -s $APP_HOME/jetsoftime/sourcefiles/patch.ips $APP_HOME/patch.ips && \
-    ln -s $APP_HOME/jetsoftime/sourcefiles/flux $APP_HOME/flux && \
-    ln -s $APP_HOME/jetsoftime/sourcefiles/patches $APP_HOME/patches && \
-    ln -s $APP_HOME/jetsoftime/sourcefiles/pickles $APP_HOME/pickles
 
 RUN chown -R ctjot:ctjot $APP_HOME
 

--- a/generator/admin.py
+++ b/generator/admin.py
@@ -1,3 +1,1 @@
-from django.contrib import admin
-
 # Register your models here.

--- a/generator/apps.py
+++ b/generator/apps.py
@@ -1,7 +1,6 @@
 import os
 
 from urllib.parse import quote, urljoin
-from collections import defaultdict
 from hashlib import md5
 from pathlib import Path
 from typing import Dict
@@ -31,7 +30,7 @@ class GeneratorConfig(AppConfig):
         so use this alternative method there.
         '''
         # map truncated path to each static file to it's MD5 checksum
-        md5sums : Dict[str, str] =  {
+        md5sums: Dict[str, str] = {
             str(Path(*path.parts[2:])): md5(path.read_bytes()).hexdigest()
             for path in Path('generator/static').rglob('*')
             if path.is_file()

--- a/generator/forms.py
+++ b/generator/forms.py
@@ -172,3 +172,4 @@ class GenerateForm(forms.Form):
     # presets
     preset_selection = forms.CharField(max_length=25, required=False)
     preset_file = forms.FileField(required=False)
+    preset = forms.CharField(widget=forms.HiddenInput(), required=True)

--- a/generator/forms.py
+++ b/generator/forms.py
@@ -67,9 +67,6 @@ class GenerateForm(forms.Form):
     game_mode = forms.CharField(max_length=15)
 
     # Character rando tab
-    char_rando_assignments = forms.CharField(
-        widget=forms.HiddenInput(), required=False
-    )
     duplicate_characters = forms.BooleanField(required=False)
     duplicate_duals = forms.BooleanField(required=False)
 
@@ -159,15 +156,6 @@ class GenerateForm(forms.Form):
     bucket_num_objs_req = forms.IntegerField()
     bucket_disable_go_modes = forms.BooleanField(required=False)
     bucket_obj_win_game = forms.BooleanField(required=False)
-
-    bucket_objective1 = forms.CharField(required=False)
-    bucket_objective2 = forms.CharField(required=False)
-    bucket_objective3 = forms.CharField(required=False)
-    bucket_objective4 = forms.CharField(required=False)
-    bucket_objective5 = forms.CharField(required=False)
-    bucket_objective6 = forms.CharField(required=False)
-    bucket_objective7 = forms.CharField(required=False)
-    bucket_objective8 = forms.CharField(required=False)
 
     # presets
     preset_selection = forms.CharField(max_length=25, required=False)

--- a/generator/forms.py
+++ b/generator/forms.py
@@ -168,3 +168,7 @@ class GenerateForm(forms.Form):
     bucket_objective6 = forms.CharField(required=False)
     bucket_objective7 = forms.CharField(required=False)
     bucket_objective8 = forms.CharField(required=False)
+
+    # presets
+    preset_selection = forms.CharField(max_length=25, required=False)
+    preset_file = forms.FileField(required=False)

--- a/generator/forms.py
+++ b/generator/forms.py
@@ -107,6 +107,7 @@ class GenerateForm(forms.Form):
     add_ozzie_spot = forms.BooleanField(required=False)
     restore_johnny_race = forms.BooleanField(required=False)
     add_racelog_spot = forms.BooleanField(required=False)
+    remove_black_omen_spot = forms.BooleanField(required=False)
     split_arris_dome = forms.BooleanField(required=False)
     rocksanity = forms.BooleanField(required=False)
     vanilla_robo_ribbon = forms.BooleanField(required=False)
@@ -122,6 +123,7 @@ class GenerateForm(forms.Form):
     mystery_game_mode_lw = forms.IntegerField()
     mystery_game_mode_loc = forms.IntegerField()
     mystery_game_mode_ia = forms.IntegerField()
+    mystery_game_mode_vr = forms.IntegerField()
     #  Item Difficulty
     mystery_item_difficulty_easy = forms.IntegerField()
     mystery_item_difficulty_normal = forms.IntegerField()
@@ -166,4 +168,3 @@ class GenerateForm(forms.Form):
     bucket_objective6 = forms.CharField(required=False)
     bucket_objective7 = forms.CharField(required=False)
     bucket_objective8 = forms.CharField(required=False)
-

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -560,8 +560,7 @@ class RandomizerInterface:
 
         :return: Random seed string.
         """
-        with open("names.txt", "r") as names_file:
-            names = names_file.readline().split(',')
+        names = randomizer.read_names()
         return "".join(random.choice(names) for i in range(2))
 
     @staticmethod

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -8,10 +8,9 @@ import random
 import re
 import sys
 import datetime
-import types
 
 from collections import OrderedDict
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 # Web types
 from .forms import GenerateForm, RomForm
@@ -25,168 +24,87 @@ sys.path.append(os.path.join(conf.BASE_DIR, 'jetsoftime', 'sourcefiles'))
 import bossrandotypes as rotypes
 import jotjson
 import logicwriters as logicwriter
+import objectivehints as obhint
 import randoconfig
 import randomizer
 import randosettings as rset
 from randosettings import GameFlags as GF
 
 
-game_mode_map = {
-    "standard": rset.GameMode.STANDARD,
-    "lost_worlds": rset.GameMode.LOST_WORLDS,
-    "ice_age": rset.GameMode.ICE_AGE,
-    "legacy_of_cyrus": rset.GameMode.LEGACY_OF_CYRUS,
-    "vanilla_rando": rset.GameMode.VANILLA_RANDO
-}
-
-shop_price_map = {
-    "normal": rset.ShopPrices.NORMAL,
-    "free": rset.ShopPrices.FREE,
-    "mostly_random": rset.ShopPrices.MOSTLY_RANDOM,
-    "fully_random": rset.ShopPrices.FULLY_RANDOM
-}
-
-difficulty_map = {
-    "easy": rset.Difficulty.EASY,
-    "normal": rset.Difficulty.NORMAL,
-    "hard": rset.Difficulty.HARD
-}
-
-tech_order_map = {
-    "normal": rset.TechOrder.NORMAL,
-    "fully_random": rset.TechOrder.FULL_RANDOM,
-    "balanced_random": rset.TechOrder.BALANCED_RANDOM
-}
-
-gameflags_dict = {
-    # Main
-    'disable_glitches': GF.FIX_GLITCH,
-    'boss_rando': GF.BOSS_RANDO,
-    'boss_scaling': GF.BOSS_SCALE,
-    'zeal': GF.ZEAL_END,
-    'early_pendant': GF.FAST_PENDANT,
-    'locked_chars': GF.LOCKED_CHARS,
-    'unlocked_magic': GF.UNLOCKED_MAGIC,
-    'tab_treasures': GF.TAB_TREASURES,
-    'chronosanity': GF.CHRONOSANITY,
-    'char_rando': GF.CHAR_RANDO,
-    'healing_item_rando': GF.HEALING_ITEM_RANDO,
-    'gear_rando': GF.GEAR_RANDO,
-    'mystery_seed': GF.MYSTERY,
-    'epoch_fail': GF.EPOCH_FAIL,
-    'duplicate_characters': GF.DUPLICATE_CHARS,
-    'duplicate_duals': GF.DUPLICATE_TECHS,
-    # This should get moved to ROSettings.
-    'boss_spot_hp': GF.BOSS_SPOT_HP,
-    # Extra
-    'unlocked_skyways': GF.UNLOCKED_SKYGATES,
-    'add_sunkeep_spot': GF.ADD_SUNKEEP_SPOT,
-    'add_bekkler_spot': GF.ADD_BEKKLER_SPOT,
-    'add_cyrus_spot': GF.ADD_CYRUS_SPOT,
-    'restore_tools': GF.RESTORE_TOOLS,
-    'add_ozzie_spot': GF.ADD_OZZIE_SPOT,
-    'restore_johnny_race': GF.RESTORE_JOHNNY_RACE,
-    'add_racelog_spot': GF.ADD_RACELOG_SPOT,
-    'remove_black_omen_spot': GF.REMOVE_BLACK_OMEN_SPOT,
-    'split_arris_dome': GF.SPLIT_ARRIS_DOME,
-    'vanilla_robo_ribbon': GF.VANILLA_ROBO_RIBBON,
-    'vanilla_desert': GF.VANILLA_DESERT,
-    'use_antilife': GF.USE_ANTILIFE,
-    'tackle_effects': GF.TACKLE_EFFECTS_ON,
-    'starters_sufficient': GF.STARTERS_SUFFICIENT,
-    'bucket_list': GF.BUCKET_LIST,
-    'rocksanity': GF.ROCKSANITY,
-    'tech_damage_rando': GF.TECH_DAMAGE_RANDO,
-    # QoL
-    'sightscope_always_on': GF.VISIBLE_HEALTH,
-    'boss_sightscope': GF.BOSS_SIGHTSCOPE,
-    'fast_tabs': GF.FAST_TABS,
-    'free_menu_glitch': GF.FREE_MENU_GLITCH,
-}
-
-# TODO: remove this and use objectivehints.get_objective_hint_aliases once merged to jetsoftime
-# Mapping of objective hint aliases mapped to objective hint strings
-# NOTE: this is ordered (python>=3.5) with more common random categories at the top
-objective_hint_aliases: Dict[str, str] = {
-    'Random': '65:quest_gated, 30:boss_nogo, 15:recruit_gated',
-    'Random Gated Quest': 'quest_gated',
-    'Random Hard Quest': 'quest_late',
-    'Random Go Mode Quest': 'quest_go',
-    'Random Gated Character Recruit': 'recruit_gated',
-    'Random Boss (Includes Go Mode Dungeons)': 'boss_any',
-    'Random Boss from Go Mode Dungeon': 'boss_go',
-    'Random Boss (No Go Mode Dungeons)': 'boss_nogo',
-    'Recruit 3 Characters (Total 5)': 'recruit_3',
-    'Recruit 4 Characters (Total 6)': 'recruit_4',
-    'Recruit 5 Characters (Total 7)': 'recruit_5',
-    'Collect 10 of 20 Fragments': 'collect_10_fragments_20',
-    'Collect 10 of 30 Fragments': 'collect_10_fragments_30',
-    'Collect 3 Rocks': 'collect_3_rocks',
-    'Collect 4 Rocks': 'collect_4_rocks',
-    'Collect 5 Rocks': 'collect_5_rocks',
-    'Forge the Masamune': 'quest_forge',
-    'Charge the Moonstone': 'quest_moonstone',
-    'Trade the Jerky Away': 'quest_jerky',
-    'Defeat the Arris Dome Boss': 'quest_arris',
-    "Visit Cyrus's Grave with Frog": 'quest_cyrus',
-    "Defeat the Boss of Death's Peak": 'quest_deathpeak',
-    'Defeat the Boss of Denadoro Mountains': 'quest_denadoro',
-    'Gain Epoch Flight': 'quest_epoch',
-    'Defeat the Boss of the Factory Ruins': 'quest_factory',
-    'Defeat the Boss of the Geno Dome': 'quest_geno',
-    "Defeat the Boss of the Giant's Claw": 'quest_claw',
-    "Defeat the Boss of Heckran's Cave": 'quest_heckran',
-    "Defeat the Boss of the King's Trial": 'quest_shard',
-    'Defeat the Boss of Manoria Cathedral': 'quest_cathedral',
-    'Defeat the Boss of Mount Woe': 'quest_woe',
-    'Defeat the Boss of the Pendant Trial': 'quest_pendant',
-    'Defeat the Boss of the Reptite Lair': 'quest_reptite',
-    'Defeat the Boss of the Sun Palace': 'quest_sunpalace',
-    'Defeat the Boss of the Sunken Desert': 'quest_desert',
-    'Defeat the Boss in the Zeal Throneroom': 'quest_zealthrone',
-    'Defeat the Boss of Zenan Bridge': 'quest_zenan',
-    'Defeat the Black Tyrano': 'quest_blacktyrano',
-    'Defeat the Tyrano Lair Midboss': 'quest_tyranomid',
-    "Defeat the Boss in Flea's Spot": 'quest_flea',
-    "Defeat the Boss in Slash's Spot": 'quest_slash',
-    "Defeat Magus in Magus's Castle": 'quest_magus',
-    'Defeat the Boss in the GigaMutant Spot': 'quest_omengiga',
-    'Defeat the Boss in the TerraMutant Spot': 'quest_omenterra',
-    'Defeat the Boss in the ElderSpawn Spot': 'quest_omenelder',
-    'Defeat the Boss in the Twin Golem Spot': 'quest_twinboss',
-    'Beat Johnny in a Race': 'quest_johnny',
-    'Bet on a Fair Race and Win': 'quest_fairrace',
-    'Play the Fair Drinking Game': 'quest_soda',
-    'Defeat AtroposXR': 'boss_atropos',
-    'Defeat DaltonPlus': 'boss_dalton',
-    'Defeat DragonTank': 'boss_dragontank',
-    'Defeat ElderSpawn': 'boss_elderspawn',
-    'Defeat Flea': 'boss_flea',
-    'Defeat Flea Plus': 'boss_fleaplus',
-    'Defeat Giga Gaia': 'boss_gigagaia',
-    'Defeat GigaMutant': 'boss_gigamutant',
-    'Defeat Golem': 'boss_golem',
-    'Defeat Golem Boss': 'boss_golemboss',
-    'Defeat Guardian': 'boss_guardian',
-    'Defeat Heckran': 'boss_heckran',
-    'Defeat LavosSpawn': 'boss_lavosspawn',
-    'Defeat Magus (North Cape)': 'boss_magusnc',
-    'Defeat Masamune': 'boss_masamune',
-    'Defeat Mother Brain': 'boss_motherbrain',
-    'Defeat Mud Imp': 'boss_mudimp',
-    'Defeat Nizbel': 'boss_nizbel',
-    'Defeat Nizbel II': 'boss_nizbel2',
-    'Defeat R-Series': 'boss_rseries',
-    'Defeat Retinite': 'boss_retinite',
-    'Defeat RustTyrano': 'boss_rusttyrano',
-    'Defeat Slash': 'boss_slash',
-    'Defeat Son of Sun': 'boss_sonofsun',
-    'Defeat Super Slash': 'boss_superslash',
-    'Defeat TerraMutant': 'boss_terramutant',
-    # Skip twinboss b/c it's in quests
-    'Defeat Yakra': 'boss_yakra',
-    'Defeat Yakra XIII': 'boss_yakraxiii',
-    'Defeat Zombor': 'boss_zombor'
+# mapping of reference in options.js to randosettings enum value
+enums_map: Dict[str, Dict[str, Any]] = {
+    "game_mode": {
+        "standard": rset.GameMode.STANDARD,
+        "lost_worlds": rset.GameMode.LOST_WORLDS,
+        "ice_age": rset.GameMode.ICE_AGE,
+        "legacy_of_cyrus": rset.GameMode.LEGACY_OF_CYRUS,
+        "vanilla_rando": rset.GameMode.VANILLA_RANDO
+    },
+    "shopprices": {
+        "normal": rset.ShopPrices.NORMAL,
+        "free": rset.ShopPrices.FREE,
+        "mostly_random": rset.ShopPrices.MOSTLY_RANDOM,
+        "fully_random": rset.ShopPrices.FULLY_RANDOM
+    },
+    "item_difficulty": {
+        "easy": rset.Difficulty.EASY,
+        "normal": rset.Difficulty.NORMAL,
+        "hard": rset.Difficulty.HARD
+    },
+    "enemy_difficulty": {
+        "normal": rset.Difficulty.NORMAL,
+        "hard": rset.Difficulty.HARD
+    },
+    "techorder": {
+        "normal": rset.TechOrder.NORMAL,
+        "full_random": rset.TechOrder.FULL_RANDOM,
+        "balanced_random": rset.TechOrder.BALANCED_RANDOM
+    },
+    "gameflags": {
+        # Main
+        'disable_glitches': GF.FIX_GLITCH,
+        'boss_rando': GF.BOSS_RANDO,
+        'boss_scaling': GF.BOSS_SCALE,
+        'zeal': GF.ZEAL_END,
+        'early_pendant': GF.FAST_PENDANT,
+        'locked_chars': GF.LOCKED_CHARS,
+        'unlocked_magic': GF.UNLOCKED_MAGIC,
+        'tab_treasures': GF.TAB_TREASURES,
+        'chronosanity': GF.CHRONOSANITY,
+        'char_rando': GF.CHAR_RANDO,
+        'healing_item_rando': GF.HEALING_ITEM_RANDO,
+        'gear_rando': GF.GEAR_RANDO,
+        'mystery_seed': GF.MYSTERY,
+        'epoch_fail': GF.EPOCH_FAIL,
+        'duplicate_characters': GF.DUPLICATE_CHARS,
+        'duplicate_duals': GF.DUPLICATE_TECHS,
+        # This should get moved to ROSettings.
+        'boss_spot_hp': GF.BOSS_SPOT_HP,
+        # Extra
+        'unlocked_skyways': GF.UNLOCKED_SKYGATES,
+        'add_sunkeep_spot': GF.ADD_SUNKEEP_SPOT,
+        'add_bekkler_spot': GF.ADD_BEKKLER_SPOT,
+        'add_cyrus_spot': GF.ADD_CYRUS_SPOT,
+        'restore_tools': GF.RESTORE_TOOLS,
+        'add_ozzie_spot': GF.ADD_OZZIE_SPOT,
+        'restore_johnny_race': GF.RESTORE_JOHNNY_RACE,
+        'add_racelog_spot': GF.ADD_RACELOG_SPOT,
+        'remove_black_omen_spot': GF.REMOVE_BLACK_OMEN_SPOT,
+        'split_arris_dome': GF.SPLIT_ARRIS_DOME,
+        'vanilla_robo_ribbon': GF.VANILLA_ROBO_RIBBON,
+        'vanilla_desert': GF.VANILLA_DESERT,
+        'use_antilife': GF.USE_ANTILIFE,
+        'tackle_effects': GF.TACKLE_EFFECTS_ON,
+        'starters_sufficient': GF.STARTERS_SUFFICIENT,
+        'bucket_list': GF.BUCKET_LIST,
+        'rocksanity': GF.ROCKSANITY,
+        'tech_damage_rando': GF.TECH_DAMAGE_RANDO,
+        # QoL
+        'sightscope_always_on': GF.VISIBLE_HEALTH,
+        'boss_sightscope': GF.BOSS_SIGHTSCOPE,
+        'fast_tabs': GF.FAST_TABS,
+        'free_menu_glitch': GF.FREE_MENU_GLITCH,
+    }
 }
 
 
@@ -321,14 +239,14 @@ class RandomizerInterface:
             settings.cosmetic_flags = cos_flags
 
             # Character/Epoch renames
-            settings.char_names[0] = self.get_character_name(form.cleaned_data['crono_name'], 'Crono')
-            settings.char_names[1] = self.get_character_name(form.cleaned_data['marle_name'], 'Marle')
-            settings.char_names[2] = self.get_character_name(form.cleaned_data['lucca_name'], 'Lucca')
-            settings.char_names[3] = self.get_character_name(form.cleaned_data['robo_name'], 'Robo')
-            settings.char_names[4] = self.get_character_name(form.cleaned_data['frog_name'], 'Frog')
-            settings.char_names[5] = self.get_character_name(form.cleaned_data['ayla_name'], 'Ayla')
-            settings.char_names[6] = self.get_character_name(form.cleaned_data['magus_name'], 'Magus')
-            settings.char_names[7] = self.get_character_name(form.cleaned_data['epoch_name'], 'Epoch')
+            settings.char_settings.names[0] = self.get_character_name(form.cleaned_data['crono_name'], 'Crono')
+            settings.char_settings.names[1] = self.get_character_name(form.cleaned_data['marle_name'], 'Marle')
+            settings.char_settings.names[2] = self.get_character_name(form.cleaned_data['lucca_name'], 'Lucca')
+            settings.char_settings.names[3] = self.get_character_name(form.cleaned_data['robo_name'], 'Robo')
+            settings.char_settings.names[4] = self.get_character_name(form.cleaned_data['frog_name'], 'Frog')
+            settings.char_settings.names[5] = self.get_character_name(form.cleaned_data['ayla_name'], 'Ayla')
+            settings.char_settings.names[6] = self.get_character_name(form.cleaned_data['magus_name'], 'Magus')
+            settings.char_settings.names[7] = self.get_character_name(form.cleaned_data['epoch_name'], 'Epoch')
 
             # In-game options
             # Boolean options
@@ -414,20 +332,20 @@ class RandomizerInterface:
             settings.seed = form.cleaned_data['seed']
 
         # Difficulties
-        settings.item_difficulty = difficulty_map[form.cleaned_data['item_difficulty']]
-        settings.enemy_difficulty = difficulty_map[form.cleaned_data['enemy_difficulty']]
+        settings.item_difficulty = enums_map['item_difficulty'][form.cleaned_data['item_difficulty']]
+        settings.enemy_difficulty = enums_map['enemy_difficulty'][form.cleaned_data['enemy_difficulty']]
 
         # game mode
-        settings.game_mode = game_mode_map[form.cleaned_data['game_mode']]
+        settings.game_mode = enums_map['game_mode'][form.cleaned_data['game_mode']]
 
         # shops
-        settings.shopprices = shop_price_map[form.cleaned_data['shop_prices']]
+        settings.shopprices = enums_map['shopprices'][form.cleaned_data['shop_prices']]
 
         # techs
-        settings.techorder = tech_order_map[form.cleaned_data['tech_rando']]
+        settings.techorder = enums_map['techorder'][form.cleaned_data['tech_rando']]
 
         settings.gameflags = GF(False)
-        for name, flag in gameflags_dict.items():
+        for name, flag in enums_map['gameflags'].items():
             if form.cleaned_data[name]:
                 settings.gameflags |= flag
 
@@ -447,7 +365,7 @@ class RandomizerInterface:
             for j in range(7):
                 if choices & (1 << j) > 0:
                     char_choices[i].append(j)
-        settings.char_choices = char_choices
+        settings.char_settings.choices = char_choices
 
         # Boss rando settings
         # TODO - Boss and location lists are just default for now. Only update the other options.
@@ -664,11 +582,44 @@ class RandomizerInterface:
     # End get_web_spoiler_log
 
     @staticmethod
-    def get_gameflags_map() -> Dict[str, str]:
+    def _jotjson_encode(data: Dict[str, Any]) -> str:
+        """Encode data into compact JSON using jotjson encoder.
+
+        This is used to convert randosettings objects (Settings, etc.) into JSON to pass to options.js.
+
+        :return: JSON string representation of data encoded via jotjson encoder
         """
-        Get mapping of form names to gameflags to encode to JSON.
+        return json.dumps(data, cls=jotjson.JOTJSONEncoder, indent=None, separators=(',', ':'))
+
+    @classmethod
+    def get_enums_map(cls) -> Dict[str, Dict[str, str]]:
         """
-        return {k: str(flag) for k, flag in gameflags_dict.items()}
+        Get mappings of values used in options.js to string repr of randosettings enums to encode to JSON.
+
+        This mapping is used in options.js to covert to/from presets, translating the form values used in JS
+        into string representations of the enums (e.g. for general options like mode, item/enemy difficulty,
+        shop prices, tech orders, etc., as well as game flags). The string representations can be loaded
+        into randosettings objects via corresponding .from_jot_json. Django converts this map to JSON during
+        templating.
+
+        :return: mappings of values used in options.js to randosettings enum string representations
+        """
+        # coerce all enums to strings to avoid getting int or List representations
+        return {key: {k: str(v) for k, v in mapping.items()} for key, mapping in enums_map.items()}
+
+    @classmethod
+    def get_inv_enums_map(cls) -> Dict[str, Dict[str, str]]:
+        """
+        Get inverted enums map, with mappings of string repr of randosettings enums mapped to options.js values.
+
+        This is enums map, but each nested dictionary is inverted, so the values and keys are swapped.
+        This is used in options.js to do lookups for string representations of randosettings enums based
+        on the values of selections or toggles in the web UI.
+
+        :return: mappings of andosettings enum string representations to values used in options.js
+        """
+        # coerce all enums to strings to avoid getting int or List representations
+        return {key: {str(v): k for k, v in mapping.items()} for key, mapping in enums_map.items()}
 
     @staticmethod
     def get_obhint_map() -> OrderedDict[str, str]:
@@ -677,11 +628,34 @@ class RandomizerInterface:
 
         :return: OrderedDict of obhint alias strings mapped to obhint strings.
         """
-        # TODO: use objectivehints.get_objective_hint_aliases once merged to jetsoftime
-        return OrderedDict(objective_hint_aliases.items())
+        return obhint.get_objective_hint_aliases()
 
     @staticmethod
-    def get_settings_defaults_json() -> str:
+    def get_presets_map() -> OrderedDict[str, Dict[str, Any]]:
+        """
+        Get preset ids mapped to their compact JSON contents.
+
+        This builds a mapping of preset 'id' keys mapped to metadata and compact JSON
+        contents. The keys are used for values in the preset selection dropdown, with
+        descriptions pulled from metadata. Those same keys are used by options.js
+        to load the appropriate preset data from the 'contents', which are rendered
+        into the 'presets-map' JSON script.
+
+        :return: OrderedDict of sorted preset id mapped to metadata and compact JSON contents
+        """
+        presets = [path for path in rset.PRESETS_PATH.rglob('*.preset.json')]
+        preset_map: Dict[str, Dict[str, Any]] = {}
+        for preset in presets:
+            contents = ' '.join(preset.read_text().split())
+            data = json.loads(preset.read_text(), cls=jotjson.JOTJSONDecoder)
+            preset_id = data['metadata']['name'].lower().replace(' ', '_')
+            preset_map[preset_id] = {
+                'metadata': data['metadata'], 'contents': contents
+            }
+        return OrderedDict(sorted(preset_map.items()))
+
+    @classmethod
+    def get_settings_defaults_json(cls) -> str:
         """
         Get the default settings object encoded as compact JSON.
 
@@ -699,62 +673,7 @@ class RandomizerInterface:
             rset.GameFlags.FIX_GLITCH | rset.GameFlags.FAST_TABS
         )
 
-        # TODO: remove this temporary monkeypatch after jetsoftime PR merged with to_jot_json updates
-        def _jot_json(self):
-            return {
-                "game_mode": str(self.game_mode),
-                "enemy_difficulty": str(self.enemy_difficulty),
-                "item_difficulty": str(self.item_difficulty),
-                "techorder": str(self.techorder),
-                "shopprices": str(self.shopprices),
-                "mystery_settings": {
-                    'game_mode_freqs': {
-                        'Standard': 75,
-                        'Lost worlds': 25,
-                        'Legacy of cyrus': 0,
-                        'Ice age': 0,
-                        'Vanilla rando': 0
-                    },
-                    'item_difficulty_freqs': {'Easy': 15, 'Normal': 70, 'Hard': 15},
-                    'enemy_difficulty_freqs': {'Normal': 75, 'Hard': 25},
-                    'tech_order_freqs': {'Normal': 10, 'Balanced random': 10, 'Full random': 80},
-                    'shop_price_freqs': {'Normal': 70, 'Mostly random': 10, 'Fully random': 10, 'Free': 10},
-                    'flag_prob_dict': {
-                        'GameFlags.TAB_TREASURES': 0.1,
-                        'GameFlags.UNLOCKED_MAGIC': 0.5,
-                        'GameFlags.BUCKET_LIST': 0.15,
-                        'GameFlags.CHRONOSANITY': 0.5,
-                        'GameFlags.BOSS_RANDO': 0.5,
-                        'GameFlags.BOSS_SCALE': 0.1,
-                        'GameFlags.LOCKED_CHARS': 0.25,
-                        'GameFlags.CHAR_RANDO': 0.5,
-                        'GameFlags.DUPLICATE_CHARS': 0.25,
-                        'GameFlags.EPOCH_FAIL': 0.5,
-                        'GameFlags.GEAR_RANDO': 0.25,
-                        'GameFlags.HEALING_ITEM_RANDO': 0.25
-                    }
-                },
-                "gameflags": self.gameflags,
-                "bucket_settings": {
-                    "disable_other_go_modes": False,
-                    "objectives_win": False,
-                    "num_objectives": 5,
-                    "num_objectives_needed": 4,
-                    "hints": [],
-                },
-                "tab_settings": {
-                    "power_min": 2,
-                    "power_max": 4,
-                    "magic_min": 1,
-                    "magic_max": 3,
-                    "speed_min": 1,
-                    "speed_max": 1,
-                },
-            }
-
-        setattr(settings, '_jot_json', types.MethodType(_jot_json, settings))
-
-        return json.dumps(settings, cls=jotjson.JOTJSONEncoder, indent=None, separators=(',', ':'))
+        return cls._jotjson_encode(settings)
 
     @staticmethod
     def get_random_seed() -> str:

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -608,6 +608,19 @@ class RandomizerInterface:
         return {key: {k: str(v) for k, v in mapping.items()} for key, mapping in enums_map.items()}
 
     @classmethod
+    def get_forced_flags_json(cls) -> str:
+        """
+        Get forced flags mapping encoded as compact JSON.
+
+        This mapping has modes/flags mapped to gameflags (under 'forced_off' or 'forced_on').
+        In the web GUI, 'forced_off' flags get forced off and disabled, instead of just relying
+        on fix_flag_conflicts to turn them off (as happens in the CLI).
+
+        :return: ForcedFlags mapping object encoded as JSON.
+        """
+        return cls._jotjson_encode(rset.ForcedFlags)
+
+    @classmethod
     def get_inv_enums_map(cls) -> Dict[str, Dict[str, str]]:
         """
         Get inverted enums map, with mappings of string repr of randosettings enums mapped to options.js values.

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -104,6 +104,10 @@ enums_map: Dict[str, Dict[str, Any]] = {
         'boss_sightscope': GF.BOSS_SIGHTSCOPE,
         'fast_tabs': GF.FAST_TABS,
         'free_menu_glitch': GF.FREE_MENU_GLITCH,
+    },
+    'roflags': {
+        'boss_spot_hp': rset.ROFlags.BOSS_SPOT_HP,
+        'legacy_boss_placement': rset.ROFlags.PRESERVE_PARTS,
     }
 }
 
@@ -370,11 +374,9 @@ class RandomizerInterface:
         # Boss rando settings
         # TODO - Boss and location lists are just default for now. Only update the other options.
         settings.ro_settings.flags = rset.ROFlags(False)
-        if form.cleaned_data['legacy_boss_placement']:
-            settings.ro_settings.flags |= rset.ROFlags.PRESERVE_PARTS
-
-        if form.cleaned_data['boss_spot_hp']:
-            settings.ro_settings.flags |= rset.ROFlags.BOSS_SPOT_HP
+        for name, flag in enums_map['roflags'].items():
+            if form.cleaned_data[name]:
+                settings.ro_settings.flags |= flag
 
         # Tab randomization settings
         # TODO - Currently defaulting to UNIFORM distribution

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -1,11 +1,17 @@
 # Python types
 from __future__ import annotations
+import copy
 import io
+import json
 import os.path
 import random
 import re
 import sys
 import datetime
+import types
+
+from collections import OrderedDict
+from typing import Dict, Optional
 
 # Web types
 from .forms import GenerateForm, RomForm
@@ -16,12 +22,13 @@ from django.conf import settings as conf
 sys.path.append(os.path.join(conf.BASE_DIR, 'jetsoftime', 'sourcefiles'))
 
 # Randomizer types
-import ctenums
 import bossrandotypes as rotypes
+import jotjson
 import logicwriters as logicwriter
 import randoconfig
 import randomizer
 import randosettings as rset
+from randosettings import GameFlags as GF
 
 
 game_mode_map = {
@@ -49,6 +56,137 @@ tech_order_map = {
     "normal": rset.TechOrder.NORMAL,
     "fully_random": rset.TechOrder.FULL_RANDOM,
     "balanced_random": rset.TechOrder.BALANCED_RANDOM
+}
+
+gameflags_dict = {
+    # Main
+    'disable_glitches': GF.FIX_GLITCH,
+    'boss_rando': GF.BOSS_RANDO,
+    'boss_scaling': GF.BOSS_SCALE,
+    'zeal': GF.ZEAL_END,
+    'early_pendant': GF.FAST_PENDANT,
+    'locked_chars': GF.LOCKED_CHARS,
+    'unlocked_magic': GF.UNLOCKED_MAGIC,
+    'tab_treasures': GF.TAB_TREASURES,
+    'chronosanity': GF.CHRONOSANITY,
+    'char_rando': GF.CHAR_RANDO,
+    'healing_item_rando': GF.HEALING_ITEM_RANDO,
+    'gear_rando': GF.GEAR_RANDO,
+    'mystery_seed': GF.MYSTERY,
+    'epoch_fail': GF.EPOCH_FAIL,
+    'duplicate_characters': GF.DUPLICATE_CHARS,
+    'duplicate_duals': GF.DUPLICATE_TECHS,
+    # This should get moved to ROSettings.
+    'boss_spot_hp': GF.BOSS_SPOT_HP,
+    # Extra
+    'unlocked_skyways': GF.UNLOCKED_SKYGATES,
+    'add_sunkeep_spot': GF.ADD_SUNKEEP_SPOT,
+    'add_bekkler_spot': GF.ADD_BEKKLER_SPOT,
+    'add_cyrus_spot': GF.ADD_CYRUS_SPOT,
+    'restore_tools': GF.RESTORE_TOOLS,
+    'add_ozzie_spot': GF.ADD_OZZIE_SPOT,
+    'restore_johnny_race': GF.RESTORE_JOHNNY_RACE,
+    'add_racelog_spot': GF.ADD_RACELOG_SPOT,
+    'remove_black_omen_spot': GF.REMOVE_BLACK_OMEN_SPOT,
+    'split_arris_dome': GF.SPLIT_ARRIS_DOME,
+    'vanilla_robo_ribbon': GF.VANILLA_ROBO_RIBBON,
+    'vanilla_desert': GF.VANILLA_DESERT,
+    'use_antilife': GF.USE_ANTILIFE,
+    'tackle_effects': GF.TACKLE_EFFECTS_ON,
+    'starters_sufficient': GF.STARTERS_SUFFICIENT,
+    'bucket_list': GF.BUCKET_LIST,
+    'rocksanity': GF.ROCKSANITY,
+    'tech_damage_rando': GF.TECH_DAMAGE_RANDO,
+    # QoL
+    'sightscope_always_on': GF.VISIBLE_HEALTH,
+    'boss_sightscope': GF.BOSS_SIGHTSCOPE,
+    'fast_tabs': GF.FAST_TABS,
+    'free_menu_glitch': GF.FREE_MENU_GLITCH,
+}
+
+# TODO: remove this and use objectivehints.get_objective_hint_aliases once merged to jetsoftime
+# Mapping of objective hint aliases mapped to objective hint strings
+# NOTE: this is ordered (python>=3.5) with more common random categories at the top
+objective_hint_aliases: Dict[str, str] = {
+    'Random': '65:quest_gated, 30:boss_nogo, 15:recruit_gated',
+    'Random Gated Quest': 'quest_gated',
+    'Random Hard Quest': 'quest_late',
+    'Random Go Mode Quest': 'quest_go',
+    'Random Gated Character Recruit': 'recruit_gated',
+    'Random Boss (Includes Go Mode Dungeons)': 'boss_any',
+    'Random Boss from Go Mode Dungeon': 'boss_go',
+    'Random Boss (No Go Mode Dungeons)': 'boss_nogo',
+    'Recruit 3 Characters (Total 5)': 'recruit_3',
+    'Recruit 4 Characters (Total 6)': 'recruit_4',
+    'Recruit 5 Characters (Total 7)': 'recruit_5',
+    'Collect 10 of 20 Fragments': 'collect_10_fragments_20',
+    'Collect 10 of 30 Fragments': 'collect_10_fragments_30',
+    'Collect 3 Rocks': 'collect_3_rocks',
+    'Collect 4 Rocks': 'collect_4_rocks',
+    'Collect 5 Rocks': 'collect_5_rocks',
+    'Forge the Masamune': 'quest_forge',
+    'Charge the Moonstone': 'quest_moonstone',
+    'Trade the Jerky Away': 'quest_jerky',
+    'Defeat the Arris Dome Boss': 'quest_arris',
+    "Visit Cyrus's Grave with Frog": 'quest_cyrus',
+    "Defeat the Boss of Death's Peak": 'quest_deathpeak',
+    'Defeat the Boss of Denadoro Mountains': 'quest_denadoro',
+    'Gain Epoch Flight': 'quest_epoch',
+    'Defeat the Boss of the Factory Ruins': 'quest_factory',
+    'Defeat the Boss of the Geno Dome': 'quest_geno',
+    "Defeat the Boss of the Giant's Claw": 'quest_claw',
+    "Defeat the Boss of Heckran's Cave": 'quest_heckran',
+    "Defeat the Boss of the King's Trial": 'quest_shard',
+    'Defeat the Boss of Manoria Cathedral': 'quest_cathedral',
+    'Defeat the Boss of Mount Woe': 'quest_woe',
+    'Defeat the Boss of the Pendant Trial': 'quest_pendant',
+    'Defeat the Boss of the Reptite Lair': 'quest_reptite',
+    'Defeat the Boss of the Sun Palace': 'quest_sunpalace',
+    'Defeat the Boss of the Sunken Desert': 'quest_desert',
+    'Defeat the Boss in the Zeal Throneroom': 'quest_zealthrone',
+    'Defeat the Boss of Zenan Bridge': 'quest_zenan',
+    'Defeat the Black Tyrano': 'quest_blacktyrano',
+    'Defeat the Tyrano Lair Midboss': 'quest_tyranomid',
+    "Defeat the Boss in Flea's Spot": 'quest_flea',
+    "Defeat the Boss in Slash's Spot": 'quest_slash',
+    "Defeat Magus in Magus's Castle": 'quest_magus',
+    'Defeat the Boss in the GigaMutant Spot': 'quest_omengiga',
+    'Defeat the Boss in the TerraMutant Spot': 'quest_omenterra',
+    'Defeat the Boss in the ElderSpawn Spot': 'quest_omenelder',
+    'Defeat the Boss in the Twin Golem Spot': 'quest_twinboss',
+    'Beat Johnny in a Race': 'quest_johnny',
+    'Bet on a Fair Race and Win': 'quest_fairrace',
+    'Play the Fair Drinking Game': 'quest_soda',
+    'Defeat AtroposXR': 'boss_atropos',
+    'Defeat DaltonPlus': 'boss_dalton',
+    'Defeat DragonTank': 'boss_dragontank',
+    'Defeat ElderSpawn': 'boss_elderspawn',
+    'Defeat Flea': 'boss_flea',
+    'Defeat Flea Plus': 'boss_fleaplus',
+    'Defeat Giga Gaia': 'boss_gigagaia',
+    'Defeat GigaMutant': 'boss_gigamutant',
+    'Defeat Golem': 'boss_golem',
+    'Defeat Golem Boss': 'boss_golemboss',
+    'Defeat Guardian': 'boss_guardian',
+    'Defeat Heckran': 'boss_heckran',
+    'Defeat LavosSpawn': 'boss_lavosspawn',
+    'Defeat Magus (North Cape)': 'boss_magusnc',
+    'Defeat Masamune': 'boss_masamune',
+    'Defeat Mother Brain': 'boss_motherbrain',
+    'Defeat Mud Imp': 'boss_mudimp',
+    'Defeat Nizbel': 'boss_nizbel',
+    'Defeat Nizbel II': 'boss_nizbel2',
+    'Defeat R-Series': 'boss_rseries',
+    'Defeat Retinite': 'boss_retinite',
+    'Defeat RustTyrano': 'boss_rusttyrano',
+    'Defeat Slash': 'boss_slash',
+    'Defeat Son of Sun': 'boss_sonofsun',
+    'Defeat Super Slash': 'boss_superslash',
+    'Defeat TerraMutant': 'boss_terramutant',
+    # Skip twinboss b/c it's in quests
+    'Defeat Yakra': 'boss_yakra',
+    'Defeat Yakra XIII': 'boss_yakraxiii',
+    'Defeat Zombor': 'boss_zombor'
 }
 
 
@@ -154,7 +292,9 @@ class RandomizerInterface:
         if not self.randomizer.has_generated:
             self.randomizer.hash_string_bytes = hash_bytes
 
-    def set_settings_and_config(self, settings: rset.Settings, config: randoconfig.RandoConfig, form: Optional[RomForm]):
+    def set_settings_and_config(
+        self, settings: rset.Settings, config: randoconfig.RandoConfig, form: Optional[RomForm]
+    ):
         """
         Populate the randomizer with a pre-populated RandoSettings object and a
         preconfigured RandoSettings object.
@@ -286,56 +426,12 @@ class RandomizerInterface:
         # techs
         settings.techorder = tech_order_map[form.cleaned_data['tech_rando']]
 
-        GF = rset.GameFlags
-        gameflags_dict = {
-            # Main
-            'disable_glitches': GF.FIX_GLITCH,
-            'boss_rando': GF.BOSS_RANDO,
-            'boss_scaling': GF.BOSS_SCALE,
-            'zeal': GF.ZEAL_END,
-            'early_pendant': GF.FAST_PENDANT,
-            'locked_chars': GF.LOCKED_CHARS,
-            'unlocked_magic': GF.UNLOCKED_MAGIC,
-            'tab_treasures': GF.TAB_TREASURES,
-            'chronosanity': GF.CHRONOSANITY,
-            'char_rando': GF.CHAR_RANDO,
-            'healing_item_rando': GF.HEALING_ITEM_RANDO,
-            'gear_rando': GF.GEAR_RANDO,
-            'mystery_seed': GF.MYSTERY,
-            'epoch_fail': GF.EPOCH_FAIL,
-            'duplicate_characters': GF.DUPLICATE_CHARS,
-            'duplicate_duals': GF.DUPLICATE_TECHS,
-            # This should get moved to ROSettings.
-            'boss_spot_hp': GF.BOSS_SPOT_HP,
-            # Extra
-            'unlocked_skyways': GF.UNLOCKED_SKYGATES,
-            'add_sunkeep_spot': GF.ADD_SUNKEEP_SPOT,
-            'add_bekkler_spot': GF.ADD_BEKKLER_SPOT,
-            'add_cyrus_spot': GF.ADD_CYRUS_SPOT,
-            'restore_tools': GF.RESTORE_TOOLS,
-            'add_ozzie_spot': GF.ADD_OZZIE_SPOT,
-            'restore_johnny_race': GF.RESTORE_JOHNNY_RACE,
-            'add_racelog_spot': GF.ADD_RACELOG_SPOT,
-            'split_arris_dome': GF.SPLIT_ARRIS_DOME,
-            'vanilla_robo_ribbon': GF.VANILLA_ROBO_RIBBON,
-            'vanilla_desert': GF.VANILLA_DESERT,
-            'use_antilife': GF.USE_ANTILIFE,
-            'tackle_effects': GF.TACKLE_EFFECTS_ON,
-            'starters_sufficient': GF.STARTERS_SUFFICIENT,
-            'bucket_list': GF.BUCKET_LIST,
-            'rocksanity': GF.ROCKSANITY,
-            'tech_damage_rando': GF.TECH_DAMAGE_RANDO,
-            # QoL
-            'sightscope_always_on': GF.VISIBLE_HEALTH,
-            'boss_sightscope': GF.BOSS_SIGHTSCOPE,
-            'fast_tabs': GF.FAST_TABS,
-            'free_menu_glitch': GF.FREE_MENU_GLITCH,
-        }
-
         settings.gameflags = GF(False)
         for name, flag in gameflags_dict.items():
             if form.cleaned_data[name]:
                 settings.gameflags |= flag
+
+        settings.initial_flags = copy.deepcopy(settings.gameflags)
 
         # Character rando
         char_choices = []
@@ -405,7 +501,8 @@ class RandomizerInterface:
             rset.GameMode.STANDARD: form.cleaned_data['mystery_game_mode_standard'],
             rset.GameMode.LOST_WORLDS: form.cleaned_data['mystery_game_mode_lw'],
             rset.GameMode.LEGACY_OF_CYRUS: form.cleaned_data['mystery_game_mode_loc'],
-            rset.GameMode.ICE_AGE: form.cleaned_data['mystery_game_mode_ia']
+            rset.GameMode.ICE_AGE: form.cleaned_data['mystery_game_mode_ia'],
+            rset.GameMode.VANILLA_RANDO: form.cleaned_data['mystery_game_mode_vr']
         }
 
         settings.mystery_settings.item_difficulty_freqs: dict[rset.Difficulty, int] = {
@@ -451,7 +548,9 @@ class RandomizerInterface:
     # End __convert_form_to_settings
 
     @classmethod
-    def get_spoiler_log(cls, config: randoconfig.RandoConfig, settings: rset.Settings, hash_bytes: Optional[bytes]) -> io.StringIO:
+    def get_spoiler_log(
+        cls, config: randoconfig.RandoConfig, settings: rset.Settings, hash_bytes: Optional[bytes]
+    ) -> io.StringIO:
         """
         Get a spoiler log file-like object.
 
@@ -471,7 +570,9 @@ class RandomizerInterface:
         return spoiler_log
 
     @classmethod
-    def get_json_spoiler_log(cls, config: randoconfig.RandoConfig, settings: rset.Settings, hash_bytes: Optional[bytes]) -> io.StringIO:
+    def get_json_spoiler_log(
+        cls, config: randoconfig.RandoConfig, settings: rset.Settings, hash_bytes: Optional[bytes]
+    ) -> io.StringIO:
         """
         Get a spoiler log file-like object.
 
@@ -555,6 +656,99 @@ class RandomizerInterface:
     # End get_web_spoiler_log
 
     @staticmethod
+    def get_gameflags_map() -> Dict[str, str]:
+        """
+        Get mapping of form names to gameflags to encode to JSON.
+        """
+        return {k: str(flag) for k, flag in gameflags_dict.items()}
+
+    @staticmethod
+    def get_obhint_map() -> OrderedDict[str, str]:
+        """
+        Get ordered dict of objective hints aliases mapped to objective hint strings.
+
+        :return: OrderedDict of obhint alias strings mapped to obhint strings.
+        """
+        # TODO: use objectivehints.get_objective_hint_aliases once merged to jetsoftime
+        return OrderedDict(objective_hint_aliases.items())
+
+    @staticmethod
+    def get_settings_defaults_json() -> str:
+        """
+        Get the default settings object encoded as compact JSON.
+
+        This turns on fast tab and disables glitches by default as well.
+        Even though those are not the defaults in Settings, they are used
+        as "defaults" in the web GUI for improved UX, especially for new
+        players.
+
+        :return: default RandoSettings object encoded as JSON.
+        """
+        settings = rset.Settings()
+
+        # turn on fast tabs and disable glitches by default
+        settings.gameflags |= (
+            rset.GameFlags.FIX_GLITCH | rset.GameFlags.FAST_TABS
+        )
+
+        # TODO: remove this temporary monkeypatch after jetsoftime PR merged with to_jot_json updates
+        def _jot_json(self):
+            return {
+                "game_mode": str(self.game_mode),
+                "enemy_difficulty": str(self.enemy_difficulty),
+                "item_difficulty": str(self.item_difficulty),
+                "techorder": str(self.techorder),
+                "shopprices": str(self.shopprices),
+                "mystery_settings": {
+                    'game_mode_freqs': {
+                        'Standard': 75,
+                        'Lost worlds': 25,
+                        'Legacy of cyrus': 0,
+                        'Ice age': 0,
+                        'Vanilla rando': 0
+                    },
+                    'item_difficulty_freqs': {'Easy': 15, 'Normal': 70, 'Hard': 15},
+                    'enemy_difficulty_freqs': {'Normal': 75, 'Hard': 25},
+                    'tech_order_freqs': {'Normal': 10, 'Balanced random': 10, 'Full random': 80},
+                    'shop_price_freqs': {'Normal': 70, 'Mostly random': 10, 'Fully random': 10, 'Free': 10},
+                    'flag_prob_dict': {
+                        'GameFlags.TAB_TREASURES': 0.1,
+                        'GameFlags.UNLOCKED_MAGIC': 0.5,
+                        'GameFlags.BUCKET_LIST': 0.15,
+                        'GameFlags.CHRONOSANITY': 0.5,
+                        'GameFlags.BOSS_RANDO': 0.5,
+                        'GameFlags.BOSS_SCALE': 0.1,
+                        'GameFlags.LOCKED_CHARS': 0.25,
+                        'GameFlags.CHAR_RANDO': 0.5,
+                        'GameFlags.DUPLICATE_CHARS': 0.25,
+                        'GameFlags.EPOCH_FAIL': 0.5,
+                        'GameFlags.GEAR_RANDO': 0.25,
+                        'GameFlags.HEALING_ITEM_RANDO': 0.25
+                    }
+                },
+                "gameflags": self.gameflags,
+                "bucket_settings": {
+                    "disable_other_go_modes": False,
+                    "objectives_win": False,
+                    "num_objectives": 5,
+                    "num_objectives_needed": 4,
+                    "hints": [],
+                },
+                "tab_settings": {
+                    "power_min": 2,
+                    "power_max": 4,
+                    "magic_min": 1,
+                    "magic_max": 3,
+                    "speed_min": 1,
+                    "speed_max": 1,
+                },
+            }
+
+        setattr(settings, '_jot_json', types.MethodType(_jot_json, settings))
+
+        return json.dumps(settings, cls=jotjson.JOTJSONEncoder, indent=None, separators=(',', ':'))
+
+    @staticmethod
     def get_random_seed() -> str:
         """
         Get a random seed string for a ROM.
@@ -586,7 +780,9 @@ class RandomizerInterface:
         return rom
 
     @classmethod
-    def get_share_details(cls, config: randoconfig.RandoConfig, settings: rset.Settings, hash_bytes: Optional[bytes]) -> io.StringIO:
+    def get_share_details(
+        cls, config: randoconfig.RandoConfig, settings: rset.Settings, hash_bytes: Optional[bytes]
+    ) -> io.StringIO:
         """
         Get details about a seed for display on the seed share page.  If this is a mystery seed then
         just display "Mystery seed!".
@@ -635,4 +831,3 @@ class RandomizerInterface:
     @staticmethod
     def clamp(value, min_val, max_val):
         return max(min_val, min(value, max_val))
-

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -11,7 +11,7 @@ import datetime
 import types
 
 from collections import OrderedDict
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 # Web types
 from .forms import GenerateForm, RomForm
@@ -434,7 +434,7 @@ class RandomizerInterface:
         settings.initial_flags = copy.deepcopy(settings.gameflags)
 
         # Character rando
-        char_choices = []
+        char_choices: List[List[int]] = []
         char_rando_assignments = form.cleaned_data['char_rando_assignments']
 
         # character rando assignments comes in as a stringified hex number.
@@ -497,7 +497,7 @@ class RandomizerInterface:
         )
 
         # Mystery
-        settings.mystery_settings.game_mode_freqs: dict[rset.GameMode, int] = {
+        game_mode_freqs: Dict[rset.GameMode, int] = {
             rset.GameMode.STANDARD: form.cleaned_data['mystery_game_mode_standard'],
             rset.GameMode.LOST_WORLDS: form.cleaned_data['mystery_game_mode_lw'],
             rset.GameMode.LEGACY_OF_CYRUS: form.cleaned_data['mystery_game_mode_loc'],
@@ -505,31 +505,31 @@ class RandomizerInterface:
             rset.GameMode.VANILLA_RANDO: form.cleaned_data['mystery_game_mode_vr']
         }
 
-        settings.mystery_settings.item_difficulty_freqs: dict[rset.Difficulty, int] = {
+        item_difficulty_freqs: Dict[rset.Difficulty, int] = {
             rset.Difficulty.EASY: form.cleaned_data['mystery_item_difficulty_easy'],
             rset.Difficulty.NORMAL: form.cleaned_data['mystery_item_difficulty_normal'],
             rset.Difficulty.HARD: form.cleaned_data['mystery_item_difficulty_hard']
         }
 
-        settings.mystery_settings.enemy_difficulty_freqs: dict[rset.Difficulty, int] = {
+        enemy_difficulty_freqs: Dict[rset.Difficulty, int] = {
             rset.Difficulty.NORMAL: form.cleaned_data['mystery_enemy_difficulty_normal'],
             rset.Difficulty.HARD: form.cleaned_data['mystery_enemy_difficulty_hard']
         }
 
-        settings.mystery_settings.tech_order_freqs: dict[rset.TechOrder, int] = {
+        tech_order_freqs: Dict[rset.TechOrder, int] = {
             rset.TechOrder.NORMAL: form.cleaned_data['mystery_tech_order_normal'],
             rset.TechOrder.BALANCED_RANDOM: form.cleaned_data['mystery_tech_order_full_random'],
             rset.TechOrder.FULL_RANDOM: form.cleaned_data['mystery_tech_order_balanced_random']
         }
 
-        settings.mystery_settings.shop_price_freqs: dict[rset.ShopPrices, int] = {
+        shop_price_freqs: Dict[rset.ShopPrices, int] = {
             rset.ShopPrices.NORMAL: form.cleaned_data['mystery_shop_prices_normal'],
             rset.ShopPrices.MOSTLY_RANDOM: form.cleaned_data['mystery_shop_prices_random'],
             rset.ShopPrices.FULLY_RANDOM: form.cleaned_data['mystery_shop_prices_mostly_random'],
             rset.ShopPrices.FREE: form.cleaned_data['mystery_shop_prices_free']
         }
 
-        settings.mystery_settings.flag_prob_dict: dict[rset.GameFlags, int] = {
+        flag_prob_dict: Dict[rset.GameFlags, int] = {
             rset.GameFlags.TAB_TREASURES: form.cleaned_data['mystery_tab_treasures']/100,
             rset.GameFlags.UNLOCKED_MAGIC: form.cleaned_data['mystery_unlock_magic']/100,
             rset.GameFlags.BUCKET_LIST: form.cleaned_data['mystery_bucket_list']/100,
@@ -543,6 +543,13 @@ class RandomizerInterface:
             rset.GameFlags.GEAR_RANDO: form.cleaned_data['mystery_gear_rando']/100,
             rset.GameFlags.HEALING_ITEM_RANDO: form.cleaned_data['mystery_heal_rando']/100
         }
+
+        settings.mystery_settings.game_mode_freqs = game_mode_freqs
+        settings.mystery_settings.item_difficulty_freqs = item_difficulty_freqs
+        settings.mystery_settings.enemy_difficulty_freqs = enemy_difficulty_freqs
+        settings.mystery_settings.tech_order_freqs = tech_order_freqs
+        settings.mystery_settings.shop_price_freqs = shop_price_freqs
+        settings.mystery_settings.flag_prob_dict = flag_prob_dict
 
         return settings
     # End __convert_form_to_settings
@@ -595,14 +602,14 @@ class RandomizerInterface:
     def get_web_spoiler_log(
             settings: rset.Settings,
             config: randoconfig.RandoConfig
-    ) -> dict[str, list[dict[str, str]]]:
+    ) -> Dict[str, List[Dict[str, str]]]:
         """
         Get a dictionary representing the spoiler log data for the given seed.
 
         :param config: RandoConfig object describing the seed
         :return: Dictionary of spoiler data
         """
-        spoiler_log = {
+        spoiler_log: Dict[str, List[Dict[str, str]]] = {
             'characters': [],
             'key_items': [],
             'bosses': [],
@@ -650,7 +657,8 @@ class RandomizerInterface:
         spheres = logicwriter.get_proof_string_from_settings_config(settings, config)
         rgx = re.compile(r'((?P<sphere>GO|(\d?)):\s*)?(?P<desc>.+)')
         for line in spheres.splitlines():
-            spoiler_log['spheres'].append(rgx.search(line).groupdict())
+            if match := rgx.search(line):
+                spoiler_log['spheres'].append(match.groupdict())
 
         return spoiler_log
     # End get_web_spoiler_log
@@ -758,8 +766,7 @@ class RandomizerInterface:
         :return: Random seed string.
         """
         with open("names.txt", "r") as names_file:
-            names = names_file.readline()
-            names = names.split(",")
+            names = names_file.readline().split(',')
         return "".join(random.choice(names) for i in range(2))
 
     @staticmethod

--- a/generator/randomizerinterface.py
+++ b/generator/randomizerinterface.py
@@ -9,7 +9,7 @@ import sys
 import datetime
 
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 # Web types
 from .forms import GenerateForm, RomForm
@@ -27,84 +27,63 @@ import objectivehints as obhint
 import randoconfig
 import randomizer
 import randosettings as rset
+import validators as vld
 from randosettings import GameFlags as GF
 
 
-# mapping of reference in options.js to randosettings enum value
-enums_map: Dict[str, Dict[str, Any]] = {
-    "game_mode": {
-        "standard": rset.GameMode.STANDARD,
-        "lost_worlds": rset.GameMode.LOST_WORLDS,
-        "ice_age": rset.GameMode.ICE_AGE,
-        "legacy_of_cyrus": rset.GameMode.LEGACY_OF_CYRUS,
-        "vanilla_rando": rset.GameMode.VANILLA_RANDO
-    },
-    "shopprices": {
-        "normal": rset.ShopPrices.NORMAL,
-        "free": rset.ShopPrices.FREE,
-        "mostly_random": rset.ShopPrices.MOSTLY_RANDOM,
-        "fully_random": rset.ShopPrices.FULLY_RANDOM
-    },
-    "item_difficulty": {
-        "easy": rset.Difficulty.EASY,
-        "normal": rset.Difficulty.NORMAL,
-        "hard": rset.Difficulty.HARD
-    },
-    "enemy_difficulty": {
-        "normal": rset.Difficulty.NORMAL,
-        "hard": rset.Difficulty.HARD
-    },
-    "techorder": {
-        "normal": rset.TechOrder.NORMAL,
-        "full_random": rset.TechOrder.FULL_RANDOM,
-        "balanced_random": rset.TechOrder.BALANCED_RANDOM
-    },
+# string representations of randosettings enums used in options.js
+enums_map: Dict[str, Union[List[str], Dict[str, str]]] = {
+    "game_mode": [str(k) for k in list(rset.GameMode)],
+    "shopprices": [str(k) for k in list(rset.ShopPrices)],
+    "item_difficulty": [str(k) for k in list(rset.Difficulty)],
+    "enemy_difficulty": [str(rset.Difficulty.NORMAL), str(rset.Difficulty.HARD)],
+    "techorder": [str(k) for k in list(rset.TechOrder)],
     "gameflags": {
         # Main
-        'disable_glitches': GF.FIX_GLITCH,
-        'boss_rando': GF.BOSS_RANDO,
-        'boss_scaling': GF.BOSS_SCALE,
-        'zeal': GF.ZEAL_END,
-        'early_pendant': GF.FAST_PENDANT,
-        'locked_chars': GF.LOCKED_CHARS,
-        'unlocked_magic': GF.UNLOCKED_MAGIC,
-        'tab_treasures': GF.TAB_TREASURES,
-        'chronosanity': GF.CHRONOSANITY,
-        'char_rando': GF.CHAR_RANDO,
-        'healing_item_rando': GF.HEALING_ITEM_RANDO,
-        'gear_rando': GF.GEAR_RANDO,
-        'mystery_seed': GF.MYSTERY,
-        'epoch_fail': GF.EPOCH_FAIL,
-        'duplicate_characters': GF.DUPLICATE_CHARS,
-        'duplicate_duals': GF.DUPLICATE_TECHS,
+        'disable_glitches': str(GF.FIX_GLITCH),
+        'boss_rando': str(GF.BOSS_RANDO),
+        'boss_scaling': str(GF.BOSS_SCALE),
+        'zeal': str(GF.ZEAL_END),
+        'early_pendant': str(GF.FAST_PENDANT),
+        'locked_chars': str(GF.LOCKED_CHARS),
+        'unlocked_magic': str(GF.UNLOCKED_MAGIC),
+        'tab_treasures': str(GF.TAB_TREASURES),
+        'chronosanity': str(GF.CHRONOSANITY),
+        'char_rando': str(GF.CHAR_RANDO),
+        'healing_item_rando': str(GF.HEALING_ITEM_RANDO),
+        'gear_rando': str(GF.GEAR_RANDO),
+        'mystery_seed': str(GF.MYSTERY),
+        'epoch_fail': str(GF.EPOCH_FAIL),
+        'duplicate_characters': str(GF.DUPLICATE_CHARS),
+        'duplicate_duals': str(GF.DUPLICATE_TECHS),
         # Extra
-        'unlocked_skyways': GF.UNLOCKED_SKYGATES,
-        'add_sunkeep_spot': GF.ADD_SUNKEEP_SPOT,
-        'add_bekkler_spot': GF.ADD_BEKKLER_SPOT,
-        'add_cyrus_spot': GF.ADD_CYRUS_SPOT,
-        'restore_tools': GF.RESTORE_TOOLS,
-        'add_ozzie_spot': GF.ADD_OZZIE_SPOT,
-        'restore_johnny_race': GF.RESTORE_JOHNNY_RACE,
-        'add_racelog_spot': GF.ADD_RACELOG_SPOT,
-        'remove_black_omen_spot': GF.REMOVE_BLACK_OMEN_SPOT,
-        'split_arris_dome': GF.SPLIT_ARRIS_DOME,
-        'vanilla_robo_ribbon': GF.VANILLA_ROBO_RIBBON,
-        'vanilla_desert': GF.VANILLA_DESERT,
-        'use_antilife': GF.USE_ANTILIFE,
-        'tackle_effects': GF.TACKLE_EFFECTS_ON,
-        'starters_sufficient': GF.STARTERS_SUFFICIENT,
-        'bucket_list': GF.BUCKET_LIST,
-        'rocksanity': GF.ROCKSANITY,
-        'tech_damage_rando': GF.TECH_DAMAGE_RANDO,
+        'unlocked_skyways': str(GF.UNLOCKED_SKYGATES),
+        'add_sunkeep_spot': str(GF.ADD_SUNKEEP_SPOT),
+        'add_bekkler_spot': str(GF.ADD_BEKKLER_SPOT),
+        'add_cyrus_spot': str(GF.ADD_CYRUS_SPOT),
+        'restore_tools': str(GF.RESTORE_TOOLS),
+        'add_ozzie_spot': str(GF.ADD_OZZIE_SPOT),
+        'restore_johnny_race': str(GF.RESTORE_JOHNNY_RACE),
+        'add_racelog_spot': str(GF.ADD_RACELOG_SPOT),
+        'remove_black_omen_spot': str(GF.REMOVE_BLACK_OMEN_SPOT),
+        'split_arris_dome': str(GF.SPLIT_ARRIS_DOME),
+        'vanilla_robo_ribbon': str(GF.VANILLA_ROBO_RIBBON),
+        'vanilla_desert': str(GF.VANILLA_DESERT),
+        'use_antilife': str(GF.USE_ANTILIFE),
+        'tackle_effects': str(GF.TACKLE_EFFECTS_ON),
+        'starters_sufficient': str(GF.STARTERS_SUFFICIENT),
+        'bucket_list': str(GF.BUCKET_LIST),
+        'rocksanity': str(GF.ROCKSANITY),
+        'tech_damage_rando': str(GF.TECH_DAMAGE_RANDO),
         # QoL
-        'sightscope_always_on': GF.VISIBLE_HEALTH,
-        'boss_sightscope': GF.BOSS_SIGHTSCOPE,
-        'fast_tabs': GF.FAST_TABS,
-        'free_menu_glitch': GF.FREE_MENU_GLITCH,
+        'sightscope_always_on': str(GF.VISIBLE_HEALTH),
+        'boss_sightscope': str(GF.BOSS_SIGHTSCOPE),
+        'fast_tabs': str(GF.FAST_TABS),
+        'free_menu_glitch': str(GF.FREE_MENU_GLITCH),
     },
     'roflags': {
-        'boss_spot_hp': rset.ROFlags.BOSS_SPOT_HP,
-        'legacy_boss_placement': rset.ROFlags.PRESERVE_PARTS,
+        'boss_spot_hp': str(rset.ROFlags.BOSS_SPOT_HP),
+        'legacy_boss_placement': str(rset.ROFlags.PRESERVE_PARTS),
     }
 }
 
@@ -455,7 +434,7 @@ class RandomizerInterface:
         return json.dumps(data, cls=jotjson.JOTJSONEncoder, indent=None, separators=(',', ':'))
 
     @classmethod
-    def get_enums_map(cls) -> Dict[str, Dict[str, str]]:
+    def get_enums_map(cls) -> Dict[str, Union[List[str], Dict[str, str]]]:
         """
         Get mappings of values used in options.js to string repr of randosettings enums to encode to JSON.
 
@@ -467,8 +446,7 @@ class RandomizerInterface:
 
         :return: mappings of values used in options.js to randosettings enum string representations
         """
-        # coerce all enums to strings to avoid getting int or List representations
-        return {key: {k: str(v) for k, v in mapping.items()} for key, mapping in enums_map.items()}
+        return enums_map
 
     @classmethod
     def get_forced_flags_json(cls) -> str:
@@ -486,16 +464,18 @@ class RandomizerInterface:
     @classmethod
     def get_inv_enums_map(cls) -> Dict[str, Dict[str, str]]:
         """
-        Get inverted enums map, with mappings of string repr of randosettings enums mapped to options.js values.
+        Get inverted flags map, with mappings of string repr of randosettings flag enums mapped to options.js values.
 
-        This is enums map, but each nested dictionary is inverted, so the values and keys are swapped.
+        This is the flags from enums_map, but each dictionary is inverted, so the values and keys are swapped.
         This is used in options.js to do lookups for string representations of randosettings enums based
         on the values of selections or toggles in the web UI.
 
         :return: mappings of andosettings enum string representations to values used in options.js
         """
-        # coerce all enums to strings to avoid getting int or List representations
-        return {key: {str(v): k for k, v in mapping.items()} for key, mapping in enums_map.items()}
+        return {
+            key: {str(v): k for k, v in mapping.items()}
+            for key, mapping in enums_map.items() if isinstance(mapping, Dict)
+        }
 
     @staticmethod
     def get_obhint_map() -> OrderedDict[str, str]:

--- a/generator/static/generator/options.js
+++ b/generator/static/generator/options.js
@@ -170,9 +170,9 @@ function applyPreset(preset) {
 
   // General options
   const gameOption = ((key) => {
-    const missing = invEnumsMap[key][settingsDefaults[key]];
+    const missing = settingsDefaults[key];
     if(!preset.settings[key]) { return missing; }
-    return invEnumsMap[key][preset.settings[key]] ?? missing;
+    return preset.settings[key] ?? missing;
   });
 
   $('#id_game_mode').val(gameOption('game_mode')).change();
@@ -453,12 +453,11 @@ function toggleFlagsRelated(id) {
 
 function toggleModeRelated() {
   const selectedMode = document.getElementById('id_game_mode').value;
-  const selectedGameMode = enumsMap.game_mode[selectedMode];
+  const selectedGameMode = selectedMode;
 
   // clear all restricted flags from all non-selected games modes "forced off"
-  const otherModes = Object.keys(enumsMap.game_mode).filter((mode) => mode != selectedMode);
-  for (const mode of otherModes) {
-    const gameMode = enumsMap.game_mode[mode];
+  const otherModes = enumsMap.game_mode.filter((mode) => mode != selectedMode);
+  for (const gameMode of otherModes) {
     const forcedOff = forcedFlagsMap.forced_off[gameMode] ?? [];
     for (const flag of forcedOff) { unrestrictFlag(flag) }
   }
@@ -815,11 +814,11 @@ function exportPreset(strict=false) {
   // metadata?
 
   // General options
-  settings['game_mode'] = enumsMap.game_mode[$('#id_game_mode').val()];
-  settings['enemy_difficulty'] = enumsMap.enemy_difficulty[$('#id_enemy_difficulty').val()];
-  settings['item_difficulty'] = enumsMap.item_difficulty[$('#id_item_difficulty').val()];
-  settings['techorder'] = enumsMap.techorder[$('#id_tech_rando').val()];
-  settings['shopprices'] = enumsMap.shopprices[$('#id_shop_prices').val()];
+  settings['game_mode'] = $('#id_game_mode').val();
+  settings['enemy_difficulty'] = $('#id_enemy_difficulty').val();
+  settings['item_difficulty'] = $('#id_item_difficulty').val();
+  settings['techorder'] = $('#id_tech_rando').val();
+  settings['shopprices'] = $('#id_shop_prices').val();
 
   // Flags
   const getCheckedFlags = ((map) => {

--- a/generator/static/generator/options.js
+++ b/generator/static/generator/options.js
@@ -64,9 +64,6 @@ const mysteryFlagSliders = {
   'mystery_heal_rando': 'healing_item_rando'
 }
 
-/* last loaded preset, just for console debugging */
-var lastPreset = {};
-
 /*
  * Creates a slider with linked text.
  * Slider element will update text when slider is moved, and update slider when text is entered.
@@ -211,7 +208,7 @@ function applyPreset(preset) {
 
   // check character choice boxes based on preset
   if(preset.settings.char_settings && preset.settings.char_settings.choices) {
-    char_choices = preset.settings.char_settings.choices;
+    let char_choices = preset.settings.char_settings.choices;
     rcUncheckAll();
     char_choices.forEach((choices, pc_index) => {
       let models = [];
@@ -296,8 +293,6 @@ function importPreset() {
     }
     else { errElem.innerHTML = ""; }
 
-    // set lastPreset, just for console debugging, not otherwise used
-    lastPreset = preset;
     applyPreset(preset);
   };
   reader.onerror = () => { errElem.innerHTML = reader.error; }
@@ -371,7 +366,7 @@ function encodeCharRandoChoices() {
  */
 function validateCharRandoChoices() {
   // ensure each character identity has at least one character model associated
-  modelMissing = charIdentities.some(identity => {
+  const modelMissing = charIdentities.some(identity => {
     return !charModels.some(model => $('#rc_' + identity + model).prop('checked'));
   });
   if (modelMissing) {
@@ -381,10 +376,10 @@ function validateCharRandoChoices() {
     return false;
   }
 
-  let duplicateCharsChecked = $('#id_duplicate_characters').prop('checked');
+  const duplicateCharsChecked = $('#id_duplicate_characters').prop('checked');
   if (!duplicateCharsChecked) {
     // ensure each character model has at least one character identity associated
-    identityMissing = charModels.some(model => {
+    const identityMissing = charModels.some(model => {
       return !charIdentities.some(identity => $('#rc_' + identity + model).prop('checked'));
     });
     if (identityMissing) {
@@ -632,16 +627,16 @@ function validateCollectObjective(collectParts){
     if (collectParts.length < 2){
         return false
     }
-    collectType = collectParts[2]
+    const collectType = collectParts[2];
     if (collectType == 'rocks'){
         if (collectParts.length != 3){return false}
-        numRocks = Number(collectParts[1])
+        const numRocks = Number(collectParts[1])
         if (!Number.isInteger(numRocks) || numRocks < 1){return false}
     } else if (collectType == 'fragments'){
         if (collectParts.length != 4){return false}
 
-        fragsNeeded = Number(collectParts[1])
-        extraFrags = Number(collectParts[3])
+        const fragsNeeded = Number(collectParts[1])
+        const extraFrags = Number(collectParts[3])
 
         if (!Number.isInteger(fragsNeeded) || fragsNeeded < 0){return false}
         if (!Number.isInteger(extraFrags) || extraFrags < 0){return false}
@@ -657,9 +652,9 @@ function validateCollectObjective(collectParts){
  */
 function validateObjective(objective){
     // If the user used a preset in the entry box, then use the dict above to resolve it.
-    cleanedObjective = objective.toLowerCase()
+    let cleanedObjective = objective.toLowerCase()
     for(let key in obhintMap){
-        if (obhintMap.hasOwnProperty(key) && key.toLowerCase() == cleanedObjective){
+        if (Object.keys(obhintMap).includes(key) && key.toLowerCase() == cleanedObjective){
             return {isValid: true, result: obhintMap[key]}
         }
     }
@@ -672,11 +667,11 @@ function validateObjective(objective){
         return {isValid: false, result: "Empty objective string."}
     }
 
-    objectiveParts = cleanedObjective.split(',')
+    const objectiveParts = cleanedObjective.split(',')
     for (let i = 0; i < objectiveParts.length; i++){
-        objectivePart = objectiveParts[i]
+        let objectivePart = objectiveParts[i]
         // split into weight:objective if possible
-        weightSplit = objectivePart.split(':')
+        const weightSplit = objectivePart.split(':')
         if (weightSplit.length > 2){
             // Some error message about unexpected ':'
             return {
@@ -685,7 +680,7 @@ function validateObjective(objective){
             }
         } else if (weightSplit.length == 2) {
             // If there was a weight, verify it's an integer
-            weight = weightSplit[0]
+            const weight = weightSplit[0]
             if (!isInteger(weight) || Number(weight) < 0){
                 return {isValid: false, result: "Weight '"+weight+"' is not a positive integer"}
             }
@@ -693,8 +688,9 @@ function validateObjective(objective){
             objectivePart = weightSplit[1]
         }
 
-        splitObjective = objectivePart.split('_')
-        objectiveType = splitObjective[0]
+        const splitObjective = objectivePart.split('_');
+        const objectiveType = splitObjective[0];
+        let ret;
 
         if (objectiveType == 'quest'){
             ret = validateQuestObjective(splitObjective)
@@ -724,44 +720,44 @@ function validateObjective(objective){
  * form fields.
  */
 function validateAndUpdateObjectives(){
-    let bucketList = document.getElementById("id_bucket_list").checked
-    if (!bucketList){return true}
+  let bucketList = document.getElementById("id_bucket_list").checked
+  if (!bucketList){return true}
 
-    let numObjs = document.getElementById("id_bucket_num_objs").value
+  let numObjs = document.getElementById("id_bucket_num_objs").value
 
-    let retFalse = false
-    for(let i = 0; i<Number(numObjs); i++){
-        let elementId = 'id_obhint_entry'+(i+1)
-        let objective = document.getElementById(elementId).value
-        const parse = validateObjective(objective)
-        const isValid = parse.isValid
-        const result = parse.result
+  let retFalse = false
+  for(let i = 0; i<Number(numObjs); i++){
+    let elementId = 'id_obhint_entry'+(i+1)
+    let objective = document.getElementById(elementId).value
+    const parse = validateObjective(objective)
+    const isValid = parse.isValid
+    const result = parse.result
 
-        if (isValid){
-            const formElementId = 'id_bucket_objective'+(i+1)
-            document.getElementById(formElementId).value = result
+    if (isValid){
+      const formElementId = 'id_bucket_objective'+(i+1)
+      document.getElementById(formElementId).value = result
 
-            const errorElementId = 'objError'+(i+1)
-            document.getElementById(errorElementId).innerHTML = ""
-        }
-        else{
-            const errorElementId = 'objError'+(i+1)
-            document.getElementById(errorElementId).innerHTML = result
-            $('a[href="#options-bucket"]').tab('show');
-            retFalse = true
-        }
-
+      const errorElementId = 'objError'+(i+1)
+      document.getElementById(errorElementId).innerHTML = ""
+    }
+    else{
+      const errorElementId = 'objError'+(i+1)
+      document.getElementById(errorElementId).innerHTML = result
+      $('a[href="#options-bucket"]').tab('show');
+      retFalse = true
     }
 
-    if (retFalse){
-        return false
-    }
+  }
 
-    for(let i=Number(numObjs); i<8; i++){
-        formElementId = 'id_bucket_objective'+(i+1)
-        document.getElementById(formElementId).value = 'None'
-    }
-    return true
+  if (retFalse){
+    return false
+  }
+
+  for(let i=Number(numObjs); i<8; i++){
+    const formElementId = 'id_bucket_objective'+(i+1)
+    document.getElementById(formElementId).value = 'None'
+  }
+  return true
 }
 
 /*
@@ -797,7 +793,7 @@ function validateLogicTweaks(){
 
     // there can be more KI than spots because can erase Jerky
     // and fix_flag_conflicts can add Robo Ribbon or remove Epoch Fail
-    allowedExtras = 1;
+    let allowedExtras = 1;
     if (!$('#id_vanilla_robo_ribbon').prop('checked')) { allowedExtras++; }
     if ($('#id_epoch_fail').prop('checked')) { allowedExtras++; }
 

--- a/generator/static/generator/seed.js
+++ b/generator/static/generator/seed.js
@@ -1,18 +1,20 @@
+/* global Cookies */
+
 // Change the spoiler log button between "Show" and "Hide"
-$(document).on('show.bs.collapse', '#spoiler_section', function(e) {
+$(document).on('show.bs.collapse', '#spoiler_section', function() {
   document.getElementById('spoiler_log_button').value = 'Hide Spoiler Log';
 });
 
-$(document).on('hide.bs.collapse', '#spoiler_section', function(e) {
+$(document).on('hide.bs.collapse', '#spoiler_section', function() {
   document.getElementById('spoiler_log_button').value = 'Show Spoiler Log';
 });
 
 // Change the cosmetic options button between "Show" and "Hide"
-$(document).on('show.bs.collapse', '#cosmetic_section', function(e) {
+$(document).on('show.bs.collapse', '#cosmetic_section', function() {
   document.getElementById('cosmetic_options_button').value = 'Hide Cosmetic Options';
 });
 
-$(document).on('hide.bs.collapse', '#cosmetic_section', function(e) {
+$(document).on('hide.bs.collapse', '#cosmetic_section', function() {
   document.getElementById('cosmetic_options_button').value = 'Show Cosmetic Options';
 });
 
@@ -27,7 +29,7 @@ function getCosmeticOptions() {
  * Update the game options section of the seed page.
  */
 function updateGameOptions() {
-  let options = getCosmeticOptions();
+  const options = getCosmeticOptions();
 
   // Update the slider text boxes
   Object.entries(options).forEach(([id, option]) => {
@@ -37,17 +39,18 @@ function updateGameOptions() {
   });
 
   // Display the chosen background type.
-  var selection = document.getElementById('id_background_selection').value;
-  preview = document.getElementById('background_selection_preview');
+  const selection = document.getElementById('id_background_selection').value;
+  const preview = document.getElementById('background_selection_preview');
   preview.className = 'menuBackground' + selection;
 }
 
+/* exported loadCosmeticOptionsCookie */
 /*
  * Load cosmetic options from cookie.
  */
 function loadCosmeticOptionsCookie() {
   // load cookie
-  let cookie = Cookies.get('ctjot_cosmetics');
+  const cookie = Cookies.get('ctjot_cosmetics');
   if (!cookie) { return; }
 
   try {
@@ -58,7 +61,7 @@ function loadCosmeticOptionsCookie() {
   if (!cosmetics) { return; }
 
   // update items from cookie
-  let options = getCosmeticOptions();
+  const options = getCosmeticOptions();
   Object.entries(options).forEach(([id, option]) => {
     let elem = document.getElementById("id_" + id);
     if (elem) {
@@ -77,6 +80,7 @@ function loadCosmeticOptionsCookie() {
   updateGameOptions();
 }
 
+/* exported saveCosmeticOptionsCookie */
 /*
  * Save cosmetic options to cookie.
  */
@@ -103,6 +107,7 @@ function saveCosmeticOptionsCookie() {
   }
 }
 
+/* exported resetCosmeticOptionsCookie */
 /*
  * Reset cosmetic options to defaults and clear cookie.
  */

--- a/generator/static/generator/styles.css
+++ b/generator/static/generator/styles.css
@@ -5,6 +5,3 @@ th,td {
   border: 1px solid black;
 }
 
-.errorText {
-  color:red;
-}

--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -3,6 +3,7 @@
 {% block imports %}
     {% load static %}
     {{ enums_map | json_script:"enums-map" }}
+    <script id="forced-flags-map" type="application/json">{{ forced_flags_json | safe }}</script>
     {{ inv_enums_map | json_script:"inv-enums-map" }}
     {{ obhint_map | json_script:"obhint-map" }}
     <script id="presets-map" type="application/json">

--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -29,6 +29,7 @@
 
       <form name="game_options_form" id="game_options_form" action="{% url 'generator:generate' %}" method="post" enctype="multipart/form-data">
         {% csrf_token %}
+        <input type="hidden" name="{{form.preset.name}}" id="{{form.preset.id_for_label}}">
 
         <h2 class="mt-3"> Select Game Options (<a href="https://wiki.ctjot.com/doku.php?id=flags" target="_blank">help</a>)</h2>
 
@@ -87,18 +88,27 @@
 
         <h2 class="mt-3">Generate Game</h2>
         <div class="border border-primary rounded p-2 mb-3">
-          <div class="form-group">
+          <div class="form-group" title="Optional seed to set (default: one will be generated).">
             <label for="{{form.seed.id_for_label}}">Seed (optional):</label>
             <input class="form-control" name="{{form.seed.name}}" id="{{form.seed.id_for_label}}" type="text">
           </div>
 
-          <div class="form-group">
+          <div class="form-group" title="Generate a spoiler log along with seed (disable this for race seeds.">
             <input type="checkbox" name="{{form.spoiler_log.name}}" id="{{form.spoiler_log.id_for_label}}" data-toggle="toggle" checked>
             <label for="{{form.spoiler_log.id_for_label}}">Spoiler Log</label>
           </div>
 
           <div class="form-group">
-            <input class="btn btn-primary" type="submit" value="Generate Seed">
+            <input class="btn btn-primary" type="submit" value="Generate Seed" title="Generate Seed based on current selected options.">
+          </div>
+
+          <div class="form-group" title="Create a differential preset (only values different from defaults).">
+            <input type="checkbox" name="diff_preset" id="id_diff_preset" data-toggle="toggle" checked>
+            <label for="id_diff_preset">Create Diff Preset</label>
+          </div>
+
+          <div class="form-group">
+            <input class="btn btn-primary" type="button" id="id_download_preset_btn" value="Download Preset" title="Download Preset JSON file based on current selected options.">
           </div>
         </div>
 

--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -2,6 +2,9 @@
 
 {% block imports %}
     {% load static %}
+    {{ gameflags_map | json_script:"gameflags-map" }}
+    {{ obhint_map | json_script:"obhint-map" }}
+    <script id="settings-defaults" type="application/json">{{ settings_defaults_json | safe }}</script>
     <script src="{% static 'generator/options.js' %}"></script>
     <link rel="stylesheet" href="{% static 'generator/styles.css' %}">
 {% endblock %}
@@ -13,15 +16,8 @@
 
       <!-- Preset buttons -->
       <h2 class="pt-4">Presets</h2>
-      <div class="border border-primary rounded p-2">
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="resetAll()">Reset All</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetRace()">Race</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetNewPlayer()">New Player</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLostWorlds()">Lost Worlds</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetHard()">Hard</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLegacyOfCyrus()">Legacy of Cyrus</button>
-      </div> <!-- End preset buttons -->
-      
+      {% include "generator/options/presets.html" %}
+
       <form name="game_options_form" id="game_options_form" action="{% url 'generator:generate' %}" method="post" enctype="multipart/form-data" onsubmit="return prepareForm()">
         {% csrf_token %}
 

--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -2,8 +2,16 @@
 
 {% block imports %}
     {% load static %}
-    {{ gameflags_map | json_script:"gameflags-map" }}
+    {{ enums_map | json_script:"enums-map" }}
+    {{ inv_enums_map | json_script:"inv-enums-map" }}
     {{ obhint_map | json_script:"obhint-map" }}
+    <script id="presets-map" type="application/json">
+    {
+      {% for preset_id, entry in presets_map.items %}
+      "{{ preset_id }}": {{ entry.contents | safe }}{% if not forloop.last %},{% endif %}
+      {% endfor %}
+    }
+    </script>
     <script id="settings-defaults" type="application/json">{{ settings_defaults_json | safe }}</script>
     <script src="{% static 'generator/options.js' %}"></script>
     <link rel="stylesheet" href="{% static 'generator/styles.css' %}">

--- a/generator/templates/generator/options.html
+++ b/generator/templates/generator/options.html
@@ -27,7 +27,7 @@
       <h2 class="pt-4">Presets</h2>
       {% include "generator/options/presets.html" %}
 
-      <form name="game_options_form" id="game_options_form" action="{% url 'generator:generate' %}" method="post" enctype="multipart/form-data" onsubmit="return prepareForm()">
+      <form name="game_options_form" id="game_options_form" action="{% url 'generator:generate' %}" method="post" enctype="multipart/form-data">
         {% csrf_token %}
 
         <h2 class="mt-3"> Select Game Options (<a href="https://wiki.ctjot.com/doku.php?id=flags" target="_blank">help</a>)</h2>

--- a/generator/templates/generator/options/bucket_tab.html
+++ b/generator/templates/generator/options/bucket_tab.html
@@ -10,7 +10,7 @@
                 </div>
                 <div class="col">
                   <input type="range" name="{{form.bucket_num_objs.name}}" id="{{form.bucket_num_objs.id_for_label}}" min="1" max="8">
-                  <input type="text" id="{{form.bucket_num_objs.id_for_label}}_text" form="none" size="1">
+                  <input type="number" id="{{form.bucket_num_objs.id_for_label}}_text" form="none" size="2" min="1" max="8">
                 </div>
                 <div class="w-100"></div>
                 <div class="col-3">
@@ -18,7 +18,7 @@
                 </div>
                 <div class="col">
                   <input type="range" name="{{form.bucket_num_objs_req.name}}" id="{{form.bucket_num_objs_req.id_for_label}}" min="1" max="8">
-                  <input type="text" id="{{form.bucket_num_objs_req.id_for_label}}_text" form="none" size="1">
+                  <input type="number" id="{{form.bucket_num_objs_req.id_for_label}}_text" form="none" size="2" min="1" max="8">
                 </div>
               </div>
               {% with '1 2 3 4 5 6 7 8' as obj_enum %}

--- a/generator/templates/generator/options/bucket_tab.html
+++ b/generator/templates/generator/options/bucket_tab.html
@@ -25,7 +25,6 @@
               {% for i in obj_enum.split %}
               <div id="objError{{i}}" class="bg-danger"></div>
               <div class="mb-1">
-                <input type="hidden" name="bucket_objective{{i}}" id="id_bucket_objective{{i}}">
                 <label class="mr-2" for="id_obhint_entry{{i}}">Objective {{i}}</label>
                 <input list="datalistOptions" id="id_obhint_entry{{i}}" name="obhint_entry{{i}}" form=none size=50 placeholder="Start typing or hit the down arrow for presets" {% if i|add:"0" > 5 %} disabled{% endif %}>
               </div>

--- a/generator/templates/generator/options/bucket_tab.html
+++ b/generator/templates/generator/options/bucket_tab.html
@@ -1,122 +1,42 @@
             <div class="border border-primary rounded p-2 mb-3">
               <datalist id="datalistOptions">
-                <option value="Random">
-                <option value="Random Gated Quest">
-                <option value="Random Hard Quest">
-                <option value="Random Go Mode Quest">
-                <option value="Random Gated Character Recruit">
-                <option value="Random Boss (Includes Go Mode Dungeons)">
-                <option value="Random Boss from Go Mode Dungeon">
-                <option value="Random Boss (No Go Mode Dungeons)">
-                <option value="Recruit a Random Gated Character">
-                <option value="Recruit 3 Characters (Total 5)">
-                <option value="Recruit 4 Characters (Total 6)">
-                <option value="Recruit 5 Characters (Total 7)">
-                <option value="Collect 10 of 20 Fragments">
-                <option value="Collect 10 of 30 Fragments">
-                <option value="Collect 3 Rocks">
-                <option value="Collect 4 Rocks">
-                <option value="Collect 5 Rocks">
-                <option value="Forge the Masamune">
-                <option value="Charge the Moonstone">
-                <option value="Trade the Jerky Away">
-                <option value="Defeat the Arris Dome Boss">
-                <option value="Visit Cyrus's Grave with Frog">
-                <option value="Defeat the Boss of Death's Peak">
-                <option value="Defeat the Boss of Denadoro Mountains">
-                <option value="Gain Epoch Flight">
-                <option value="Defeat the Boss of the Factory Ruins">
-                <option value="Defeat the Boss of the Geno Dome">
-                <option value="Defeat the Boss of the Giant's Claw">
-                <option value="Defeat the Boss of Heckran Cave">
-                <option value="Defeat the Boss of the King's Trial">
-                <option value="Defeat the Boss of Manoria Cathedral">
-                <option value="Defeat the Boss of Mount Woe">
-                <option value="Defeat the Boss of the Pendant Trial">
-                <option value="Defeat the Boss of the Reptite Lair">
-                <option value="Defeat the Boss of the Sun Palace">
-                <option value="Defeat the Boss of the Sunken Desert">
-                <option value="Defeat the Boss in the Zeal Throneroom">
-                <option value="Defeat the Boss of Zenan Bridge">
-                <option value="Defeat the Black Tyrano">
-                <option value="Defeat the Tyrano Lair Midboss">
-                <option value="Defeat the Boss in Flea's Spot">
-                <option value="Defeat the Boss in Slash's Spot">
-                <option value="Defeat Magus in Magus's Castle">
-                <option value="Defeat the Boss in the GigaMutant Spot">
-                <option value="Defeat the Boss in the TerraMutant Spot">
-                <option value="Defeat the Boss in the ElderSpawn Spot">
-                <option value="Defeat the Boss in the Twin Golem Spot">
-                <option value="Beat Johnny in a Race">
-                <option value="Bet on a Fair Race and Win">
-                <option value="Play the Fair Drinking Game">
-                <option value="Defeat AtroposXR">
-                <option value="Defeat DaltonPlus">
-                <option value="Defeat DragonTank">
-                <option value="Defeat ElderSpawn">
-                <option value="Defeat Flea">
-                <option value="Defeat Flea Plus">
-                <option value="Defeat Giga Gaia">
-                <option value="Defeat GigaMutant">
-                <option value="Defeat Golem">
-                <option value="Defeat Golem Boss">
-                <option value="Defeat Guardian">
-                <option value="Defeat Heckran">
-                <option value="Defeat LavosSpawn">
-                <option value="Defeat Magus (North Cape)">
-                <option value="Defeat Masamune">
-                <option value="Defeat Mother Brain">
-                <option value="Defeat Mud Imp">
-                <option value="Defeat Nizbel">
-                <option value="Defeat Nizbel II">
-                <option value="Defeat R-Series">
-                <option value="Defeat Retinite">
-                <option value="Defeat RustTyrano">
-                <option value="Defeat Slash">
-                <option value="Defeat Son of Sun">
-                <option value="Defeat Super Slash">
-                <option value="Defeat TerraMutant">
-                <option value="Defeat Yakra">
-                <option value="Defeat Yakra XIII">
-                <option value="Defeat Zombor">
-                <option value="Recruit Crono">
-                <option value="Recruit Marle">
-                <option value="Recruit Lucca">
-                <option value="Recruit Robo">
-                <option value="Recruit Frog">
-                <option value="Recruit Ayla">
-                <option value="Recruit Magus">
-                <option value="Recruit the Guardia Castle Character">
-                <option value="Recruit the Dactyl Nest Character">
-                <option value="Recruit the Proto Dome Character">
-                <option value="Recruit the Frog's Burrow Character">
+                {% for alias in obhint_map.keys %}
+                <option value="{{ alias }}">
+                {% endfor %}
               </datalist>
-              <div>
-              <label for="{{form.bucket_num_objs.id_for_label}}"> Number of Objectives</label>
-              <input type="range" name="{{form.bucket_num_objs.name}}" id="{{form.bucket_num_objs.id_for_label}}" min="1" max="8" value="5" oninput="updateObjectiveCount(false)" onchange="updateObjectiveCount(false)">
-              <input type="text" id="numObjectivesDisp" form="none" size="1" value="5" readonly>
+              <div class="form-row mb-2">
+                <div class="col-3">
+                  <label for="{{form.bucket_num_objs.id_for_label}}"> Number of Objectives</label>
+                </div>
+                <div class="col">
+                  <input type="range" name="{{form.bucket_num_objs.name}}" id="{{form.bucket_num_objs.id_for_label}}" min="1" max="8">
+                  <input type="text" id="{{form.bucket_num_objs.id_for_label}}_text" form="none" size="1">
+                </div>
+                <div class="w-100"></div>
+                <div class="col-3">
+                  <label for="{{form.bucket_num_objs_req.id_for_label}}"> Number Required</label>
+                </div>
+                <div class="col">
+                  <input type="range" name="{{form.bucket_num_objs_req.name}}" id="{{form.bucket_num_objs_req.id_for_label}}" min="1" max="8">
+                  <input type="text" id="{{form.bucket_num_objs_req.id_for_label}}_text" form="none" size="1">
+                </div>
+              </div>
+              {% with '1 2 3 4 5 6 7 8' as obj_enum %}
+              {% for i in obj_enum.split %}
+              <div id="objError{{i}}" class="bg-danger"></div>
+              <div class="mb-1">
+                <input type="hidden" name="bucket_objective{{i}}" id="id_bucket_objective{{i}}">
+                <label class="mr-2" for="id_obhint_entry{{i}}">Objective {{i}}</label>
+                <input list="datalistOptions" id="id_obhint_entry{{i}}" name="obhint_entry{{i}}" form=none size=50 placeholder="Start typing or hit the down arrow for presets" {% if i|add:"0" > 5 %} disabled{% endif %}>
+              </div>
+              {% endfor %}
+              {% endwith %}
+              <div class="form-group form-check pl-0">
+                <input type="checkbox" name="{{form.bucket_disable_go_modes.name}}" id="{{form.bucket_disable_go_modes.id_for_label}}"  data-toggle="toggle">
+                <label for="{{form.bucket_disable_go_modes.id_for_label}}">Disable Other Go Modes</label>
+              </div>
+              <div class="form-group form-check pl-0">
+                <input type="checkbox" name="{{form.bucket_obj_win_game.name}}" id="{{form.bucket_obj_win_game.id_for_label}}"  data-toggle="toggle">
+                <label for="{{form.bucket_obj_win_game.id_for_label}}">Objectives Auto-Win</label>
+              </div>
             </div>
-            <div>
-              <label for="{{form.bucket_num_objs_req.id_for_label}}"> Number Required</label>
-              <input type="range" name="{{form.bucket_num_objs_req.name}}" id="{{form.bucket_num_objs_req.id_for_label}}" min="1" max="8" value="4" oninput="updateObjectiveCount(true)" onchange="updateObjectiveCount(true)" >
-              <input type="text" id="numObjectivesRequiredDisp" form="none" size="1" value="4" readonly>
-            </div>
-            {% with '1 2 3 4 5 6 7 8' as obj_enum %}
-            {% for i in obj_enum.split %}
-            <div id="objError{{i}}" class=errorText></div>
-	    <div>
-              <input type="hidden" name="bucket_objective{{i}}" id="id_bucket_objective{{i}}">
-              <label for="objEntry{{i}}">Objective {{i}}</label>
-              <input list="datalistOptions", id="objEntry{{i}}" name="objEntry{{i}}" form=none size=50 placeholder="Start typing or hit the down arrow for presets" {% if i|add:"0" > 5 %} disabled{% endif %}>
-	    </div>
-            {% endfor %}
-            {% endwith %}
-            <div class="form-group form-check pl-0">
-              <input type="checkbox" name="{{form.bucket_disable_go_modes.name}}" id="{{form.bucket_disable_go_modes.id_for_label}}"  data-toggle="toggle">
-              <label for="{{form.bucket_disable_go_modes.id_for_label}}">Disable Other Go Modes</label>
-            </div>
-            <div class="form-group form-check pl-0">
-              <input type="checkbox" name="{{form.bucket_obj_win_game.name}}" id="{{form.bucket_obj_win_game.id_for_label}}"  data-toggle="toggle">
-              <label for="{{form.bucket_obj_win_game.id_for_label}}">Objectives Auto-Win</label>
-            </div>
-</div>

--- a/generator/templates/generator/options/char_rando_tab.html
+++ b/generator/templates/generator/options/char_rando_tab.html
@@ -16,7 +16,7 @@
               <div class="border border-secondary rounded p-2 mb-3 mt-3 collapse" id="character_selection_matrix">
                 <input type="hidden" name="{{form.char_rando_assignments.name}}" id="{{form.char_rando_assignments.id_for_label}}">
                 <p>Select which character identities can be assigned which character models:</p>
-                <div id="character_selection_error" class="errorText"></div>
+                <div id="character_selection_error" class="bg-danger"></div>
                 <table>
                   <tr>
                     <th></th>

--- a/generator/templates/generator/options/char_rando_tab.html
+++ b/generator/templates/generator/options/char_rando_tab.html
@@ -14,7 +14,6 @@
               <input type="button" class="btn btn-outline-primary" id="char_rando_assignments_button" value="Limit Character Assignments" data-toggle="collapse" data-target="#character_selection_matrix" aria-expanded="false" aria-controls="character_selection_matrix">
 
               <div class="border border-secondary rounded p-2 mb-3 mt-3 collapse" id="character_selection_matrix">
-                <input type="hidden" name="{{form.char_rando_assignments.name}}" id="{{form.char_rando_assignments.id_for_label}}">
                 <p>Select which character identities can be assigned which character models:</p>
                 <div id="character_selection_error" class="bg-danger"></div>
                 <table>

--- a/generator/templates/generator/options/char_rando_tab.html
+++ b/generator/templates/generator/options/char_rando_tab.html
@@ -2,12 +2,12 @@
             <div class="tab-content border border-primary rounded p-2 mb-3">
 
               <div class="form-group form-check pt-3 pl-0">
-                <input type="checkbox" name="{{form.duplicate_characters.name}}" id="{{form.duplicate_characters.id_for_label}}" data-toggle="toggle" onchange="disableDuplicateTechs()" />
+                <input type="checkbox" name="{{form.duplicate_characters.name}}" id="{{form.duplicate_characters.id_for_label}}" data-toggle="toggle">
                 <label for="{{form.duplicate_characters.id_for_label}}">Duplicate Characters</label>
               </div>
 
               <div class="form-group form-check pt-3 pl-0">
-                <input type="checkbox" name="{{form.duplicate_duals.name}}" id="{{form.duplicate_duals.id_for_label}}" data-toggle="toggle" />
+                <input type="checkbox" name="{{form.duplicate_duals.name}}" id="{{form.duplicate_duals.id_for_label}}" data-toggle="toggle">
                 <label for="{{form.duplicate_duals.id_for_label}}">Duplicate Dual Techs</label>
               </div>
 
@@ -45,8 +45,8 @@
                 {% endwith %}
                 </table>
                 <div class="pt-2">
-                  <input class="btn btn-outline-primary btn-sm" type="button" form="none" value="Check All" onclick="rcCheckAll()">
-                  <input class="btn btn-outline-primary btn-sm" type="button" form="none" value="Uncheck All" onclick="rcUncheckAll()">
+                  <input class="btn btn-outline-primary btn-sm" type="button" form="none" value="Check All" id="id_rc_check_all">
+                  <input class="btn btn-outline-primary btn-sm" type="button" form="none" value="Uncheck All" id="id_rc_uncheck_all">
                 </div>
               </div>
 

--- a/generator/templates/generator/options/extra_tab.html
+++ b/generator/templates/generator/options/extra_tab.html
@@ -1,84 +1,123 @@
+<div class="border border-primary rounded p-2 mb-3">
 
-            <div class="border border-primary rounded p-2 mb-3">
-              <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.use_antilife.name}}" id="{{form.use_antilife.id_for_label}}"  data-toggle="toggle">
-                <label for="{{form.use_antilife.id_for_label}}">Use Anti-Life</label>
-              </div>
-              <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.tackle_effects.name}}" id="{{form.tackle_effects.id_for_label}}"  data-toggle="toggle">
-                <label for="{{form.tackle_effects.id_for_label}}">Tackle On-Hit Effects</label>
-              </div>
-              <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.starters_sufficient.name}}" id="{{form.starters_sufficient.id_for_label}}"  data-toggle="toggle">
-                <label for="{{form.starters_sufficient.id_for_label}}">Starters Sufficient</label>
-              </div>
-              <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.bucket_list.name}}" id="{{form.bucket_list.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('bucket_list')">
-                <label for="{{form.bucket_list.id_for_label}}">Bucket List</label>
-              </div>
-              <div class="form-group form-check pl-0">
-                <input type="checkbox" name="{{form.tech_damage_rando.name}}" id="{{form.tech_damage_rando.id_for_label}}"  data-toggle="toggle">
-                <label for="{{form.tech_damage_rando.id_for_label}}">Tech Damage Rando</label>
-              </div>
-	      <div>
-		<h4>Logic Tweaks</h4>
-		<div id="logicTweakError" class=errorText></div>
-		<p>Flags that Add a Key Item:</p>
-		<div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.restore_johnny_race.name}}" id="{{form.restore_johnny_race.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.restore_johnny_race.id_for_label}}">Restore Johnny Race</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.restore_tools.name}}" id="{{form.restore_tools.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.restore_tools.id_for_label}}">Restore Tools</label>
-		  </div>
-		</div>
-		<p>Flags that Add a Key Item Spot:</p>
-		<div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.add_bekkler_spot.name}}" id="{{form.add_bekkler_spot.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.add_bekkler_spot.id_for_label}}">Add Bekkler Spot</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.add_ozzie_spot.name}}" id="{{form.add_ozzie_spot.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.add_ozzie_spot.id_for_label}}">Add Ozzie's Fort Spot</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.add_racelog_spot.name}}" id="{{form.add_racelog_spot.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.add_racelog_spot.id_for_label}}">Add Race Log Spot</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.vanilla_robo_ribbon.name}}" id="{{form.vanilla_robo_ribbon.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.vanilla_robo_ribbon.id_for_label}}">Vanilla Robo Ribbon</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.add_cyrus_spot.name}}" id="{{form.add_cyrus_spot.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.add_cyrus_spot.id_for_label}}">Add Cyrus Grave Spot</label>
-		  </div>
-		</div>
-		<p>Flags that are Spot-Neutral:</p>
-		<div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.unlocked_skyways.name}}" id="{{form.unlocked_skyways.id_for_label}}" data-toggle="toggle" onchange="toggleUnlockedSkywaysRelated()">
-                    <label for="{{form.unlocked_skyways.id_for_label}}">Unlocked Skyways</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.add_sunkeep_spot.name}}" id="{{form.add_sunkeep_spot.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.add_sunkeep_spot.id_for_label}}">Add Sun Keep Spot</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.split_arris_dome.name}}" id="{{form.split_arris_dome.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.split_arris_dome.id_for_label}}">Split Arris Dome</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.vanilla_desert.name}}" id="{{form.vanilla_desert.id_for_label}}"  data-toggle="toggle">
-                    <label for="{{form.vanilla_desert.id_for_label}}">Vanilla Desert</label>
-		  </div>
-		  <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.rocksanity.name}}" id="{{form.rocksanity.id_for_label}}" data-toggle="toggle" onchange="toggleRocksanityRelated()">
-                    <label for="{{form.rocksanity.id_for_label}}">Rocksanity</label>
-		  </div>
-		</div>
-	      </div>
-            </div>
+  <div class="row align-items-start">
+    <div class="col-sm">
+      <div class="form-group form-check pl-0">
+        <input type="checkbox" name="{{form.bucket_list.name}}" id="{{form.bucket_list.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('bucket_list')">
+        <label for="{{form.bucket_list.id_for_label}}">Bucket List</label>
+      </div>
+      <div class="form-group form-check pl-0">
+        <input type="checkbox" name="{{form.starters_sufficient.name}}" id="{{form.starters_sufficient.id_for_label}}" data-toggle="toggle">
+        <label for="{{form.starters_sufficient.id_for_label}}">Starters Sufficient</label>
+      </div>
+      <div class="form-group form-check pl-0">
+        <input type="checkbox" name="{{form.tech_damage_rando.name}}" id="{{form.tech_damage_rando.id_for_label}}" data-toggle="toggle">
+        <label for="{{form.tech_damage_rando.id_for_label}}">Tech Damage Rando</label>
+      </div>
+    </div>
+    <div class="col-sm">
+      <div class="form-group form-check pl-0">
+        <input type="checkbox" name="{{form.tackle_effects.name}}" id="{{form.tackle_effects.id_for_label}}" data-toggle="toggle">
+        <label for="{{form.tackle_effects.id_for_label}}">Tackle On-Hit Effects</label>
+      </div>
+      <div class="form-group form-check pl-0">
+        <input type="checkbox" name="{{form.use_antilife.name}}" id="{{form.use_antilife.id_for_label}}" data-toggle="toggle">
+        <label for="{{form.use_antilife.id_for_label}}">Use Anti-Life</label>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <h4>Logic Tweaks</h4>
+    <div id="logicTweakError" class="bg-danger"></div>
+
+    <div class="row">
+      <div class="col-sm"><p><b>Flags that Add a Key Item:</b></p></div>
+    </div>
+
+    <div class="row align-items-start">
+      <div class="col-sm">
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.restore_johnny_race.name}}" id="{{form.restore_johnny_race.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.restore_johnny_race.id_for_label}}">Restore Johnny Race</label>
+        </div>
+      </div>
+
+      <div class="col-sm">
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.restore_tools.name}}" id="{{form.restore_tools.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.restore_tools.id_for_label}}">Restore Tools</label>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm"><p><b>Flags that Add/Remove a Key Item Spot:</b></p></div>
+    </div>
+
+    <div class="row align-items-start">
+      <div class="col-sm">
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.add_bekkler_spot.name}}" id="{{form.add_bekkler_spot.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.add_bekkler_spot.id_for_label}}">Add Bekkler Spot</label>
+        </div>
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.add_cyrus_spot.name}}" id="{{form.add_cyrus_spot.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.add_cyrus_spot.id_for_label}}">Add Cyrus Grave Spot</label>
+        </div>
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.add_ozzie_spot.name}}" id="{{form.add_ozzie_spot.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.add_ozzie_spot.id_for_label}}">Add Ozzie's Fort Spot</label>
+        </div>
+      </div>
+
+      <div class="col-sm">
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.add_racelog_spot.name}}" id="{{form.add_racelog_spot.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.add_racelog_spot.id_for_label}}">Add Race Log Spot</label>
+        </div>
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.vanilla_robo_ribbon.name}}" id="{{form.vanilla_robo_ribbon.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.vanilla_robo_ribbon.id_for_label}}">Vanilla Robo Ribbon</label>
+        </div>
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.remove_black_omen_spot.name}}" id="{{form.remove_black_omen_spot.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.remove_black_omen_spot.id_for_label}}">Remove Black Omen Spot</label>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="col-sm"><p><b>Flags that are Spot-Neutral:</b></p></div>
+    </div>
+
+    <div class="row align-items-start">
+      <div class="col-sm">
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.add_sunkeep_spot.name}}" id="{{form.add_sunkeep_spot.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.add_sunkeep_spot.id_for_label}}">Add Sun Keep Spot</label>
+        </div>
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.split_arris_dome.name}}" id="{{form.split_arris_dome.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.split_arris_dome.id_for_label}}">Split Arris Dome</label>
+        </div>
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.vanilla_desert.name}}" id="{{form.vanilla_desert.id_for_label}}" data-toggle="toggle">
+          <label for="{{form.vanilla_desert.id_for_label}}">Vanilla Desert</label>
+        </div>
+      </div>
+
+      <div class="col-sm">
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.unlocked_skyways.name}}" id="{{form.unlocked_skyways.id_for_label}}" data-toggle="toggle" onchange="toggleUnlockedSkywaysRelated()">
+          <label for="{{form.unlocked_skyways.id_for_label}}">Unlocked Skyways</label>
+        </div>
+        <div class="form-group form-check pl-0">
+          <input type="checkbox" name="{{form.rocksanity.name}}" id="{{form.rocksanity.id_for_label}}" data-toggle="toggle" onchange="toggleRocksanityRelated()">
+          <label for="{{form.rocksanity.id_for_label}}">Rocksanity</label>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>

--- a/generator/templates/generator/options/extra_tab.html
+++ b/generator/templates/generator/options/extra_tab.html
@@ -3,7 +3,7 @@
   <div class="row align-items-start">
     <div class="col-sm">
       <div class="form-group form-check pl-0">
-        <input type="checkbox" name="{{form.bucket_list.name}}" id="{{form.bucket_list.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('bucket_list')">
+        <input type="checkbox" name="{{form.bucket_list.name}}" id="{{form.bucket_list.id_for_label}}" data-toggle="toggle">
         <label for="{{form.bucket_list.id_for_label}}">Bucket List</label>
       </div>
       <div class="form-group form-check pl-0">
@@ -109,11 +109,11 @@
 
       <div class="col-sm">
         <div class="form-group form-check pl-0">
-          <input type="checkbox" name="{{form.unlocked_skyways.name}}" id="{{form.unlocked_skyways.id_for_label}}" data-toggle="toggle" onchange="toggleUnlockedSkywaysRelated()">
+          <input type="checkbox" name="{{form.unlocked_skyways.name}}" id="{{form.unlocked_skyways.id_for_label}}" data-toggle="toggle">
           <label for="{{form.unlocked_skyways.id_for_label}}">Unlocked Skyways</label>
         </div>
         <div class="form-group form-check pl-0">
-          <input type="checkbox" name="{{form.rocksanity.name}}" id="{{form.rocksanity.id_for_label}}" data-toggle="toggle" onchange="toggleRocksanityRelated()">
+          <input type="checkbox" name="{{form.rocksanity.name}}" id="{{form.rocksanity.id_for_label}}" data-toggle="toggle">
           <label for="{{form.rocksanity.id_for_label}}">Rocksanity</label>
         </div>
       </div>

--- a/generator/templates/generator/options/general_tab.html
+++ b/generator/templates/generator/options/general_tab.html
@@ -5,11 +5,9 @@
               <div class="form-group mb-4">
                 <label for="{{form.game_mode.id_for_label}}">Game Mode:</label>
                 <select class="form-control" name="{{form.game_mode.name}}" id="{{form.game_mode.id_for_label}}">
-                  <option value="standard" selected>Standard</option>
-                  <option value="lost_worlds">Lost Worlds</option>
-                  <option value="ice_age">Ice Age</option>
-                  <option value="legacy_of_cyrus">Legacy of Cyrus</option>
-                  <option value="vanilla_rando">Vanilla Rando</option>
+                  {% for mode in enums_map.game_mode %}
+                  <option value="{{ mode }}">{{ mode }}</option>
+                  {% endfor %}
                 </select>
               </div>
 
@@ -19,8 +17,9 @@
                   <div class="form-group mb-4">
                     <label for="{{form.enemy_difficulty.id_for_label}}">Enemy Difficulty:</label>
                     <select class="form-control" name="{{form.enemy_difficulty.name}}" id="{{form.enemy_difficulty.id_for_label}}">
-                      <option value="normal" selected>Normal</option>
-                      <option value="hard">Hard</option>
+                      {% for diff in enums_map.enemy_difficulty %}
+                      <option value="{{ diff }}">{{ diff }}</option>
+                      {% endfor %}
                     </select>
                   </div>
 
@@ -65,9 +64,9 @@
                   <div class="form-group mb-4">
                     <label for="{{form.item_difficulty.id_for_label}}">Item Difficulty:</label>
                     <select class="form-control" name="{{form.item_difficulty.name}}" id="{{form.item_difficulty.id_for_label}}">
-                      <option value="easy">Easy</option>
-                      <option value="normal" selected>Normal</option>
-                      <option value="hard">Hard</option>
+                      {% for diff in enums_map.item_difficulty %}
+                      <option value="{{ diff }}">{{ diff }}</option>
+                      {% endfor %}
                     </select>
                   </div>
 
@@ -112,19 +111,18 @@
               <div class="form-group">
                 <label for="{{form.shop_prices.id_for_label}}">Shop Prices:</label>
                 <select class="form-control" name="{{form.shop_prices.name}}" id="{{form.shop_prices.id_for_label}}">
-                  <option value="normal" selected>Normal</option>
-                  <option value="free">Free</option>
-                  <option value="mostly_random">Mostly Random</option>
-                  <option value="fully_random">Fully Random</option>
+                  {% for shopprice in enums_map.shopprices %}
+                  <option value="{{ shopprice }}">{{ shopprice }}</option>
+                  {% endfor %}
                 </select>
               </div>
 
               <div class="form-group">
                 <label for="{{form.tech_rando.id_for_label}}">Tech Randomization:</label>
                 <select class="form-control" name="{{form.tech_rando.name}}" id="{{form.tech_rando.id_for_label}}">
-                  <option value="normal" selected>Normal</option>
-                  <option value="balanced_random">Balanced Random</option>
-                  <option value="full_random">Fully Random</option>
+                  {% for techorder in enums_map.techorder %}
+                  <option value="{{ techorder }}">{{ techorder }}</option>
+                  {% endfor %}
                 </select>
               </div>
             </div> <!-- End Game Flags -->

--- a/generator/templates/generator/options/general_tab.html
+++ b/generator/templates/generator/options/general_tab.html
@@ -124,7 +124,7 @@
                 <select class="form-control" name="{{form.tech_rando.name}}" id="{{form.tech_rando.id_for_label}}">
                   <option value="normal" selected>Normal</option>
                   <option value="balanced_random">Balanced Random</option>
-                  <option value="fully_random">Fully Random</option>
+                  <option value="full_random">Fully Random</option>
                 </select>
               </div>
             </div> <!-- End Game Flags -->

--- a/generator/templates/generator/options/general_tab.html
+++ b/generator/templates/generator/options/general_tab.html
@@ -4,7 +4,7 @@
 
               <div class="form-group mb-4">
                 <label for="{{form.game_mode.id_for_label}}">Game Mode:</label>
-                <select class="form-control" name="{{form.game_mode.name}}" id="{{form.game_mode.id_for_label}}" onchange="restrictFlags()">
+                <select class="form-control" name="{{form.game_mode.name}}" id="{{form.game_mode.id_for_label}}">
                   <option value="standard" selected>Standard</option>
                   <option value="lost_worlds">Lost Worlds</option>
                   <option value="ice_age">Ice Age</option>
@@ -55,7 +55,7 @@
                   </div>
 
                   <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.mystery_seed.name}}" id="{{form.mystery_seed.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('mystery_seed')">
+                    <input type="checkbox" name="{{form.mystery_seed.name}}" id="{{form.mystery_seed.id_for_label}}" data-toggle="toggle">
                     <label for="{{form.mystery_seed.id_for_label}}">Mystery Seed</label>
                   </div>
                 </div>
@@ -72,7 +72,7 @@
                   </div>
 
                   <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.boss_rando.name}}" id="{{form.boss_rando.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('boss_rando')">
+                    <input type="checkbox" name="{{form.boss_rando.name}}" id="{{form.boss_rando.id_for_label}}" data-toggle="toggle">
                     <label for="{{form.boss_rando.id_for_label}}">Randomize Bosses</label>
                   </div>
 
@@ -92,7 +92,7 @@
                   </div>
 
                   <div class="form-group form-check pl-0">
-                    <input type="checkbox" name="{{form.char_rando.name}}" id="{{form.char_rando.id_for_label}}" data-toggle="toggle" onchange="toggleOptions('char_rando')">
+                    <input type="checkbox" name="{{form.char_rando.name}}" id="{{form.char_rando.id_for_label}}" data-toggle="toggle">
                     <label for="{{form.char_rando.id_for_label}}">Randomize Characters</label>
                   </div>
 

--- a/generator/templates/generator/options/mystery_tab.html
+++ b/generator/templates/generator/options/mystery_tab.html
@@ -4,180 +4,180 @@
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_standard.id_for_label}}" class="form-label mr-2">Standard:</label>
                 <input type="range" class="form-range" name="{{form.mystery_game_mode_standard.name}}" id="{{form.mystery_game_mode_standard.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_game_mode_standard.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_game_mode_standard.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_lw.id_for_label}}" class="form-label mr-2">Lost Worlds:</label>
                 <input type="range" class="form-range" name="{{form.mystery_game_mode_lw.name}}" id="{{form.mystery_game_mode_lw.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_game_mode_lw.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_game_mode_lw.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_loc.id_for_label}}" class="form-label mr-2">Legacy of Cyrus:</label>
                 <input type="range" class="form-range" name="{{form.mystery_game_mode_loc.name}}" id="{{form.mystery_game_mode_loc.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_game_mode_loc.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_game_mode_loc.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_ia.id_for_label}}" class="form-label mr-2">Ice Age:</label>
                 <input type="range" class="form-range" name="{{form.mystery_game_mode_ia.name}}" id="{{form.mystery_game_mode_ia.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_game_mode_ia.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_game_mode_ia.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_vr.id_for_label}}" class="form-label mr-2">Vanilla Rando:</label>
                 <input type="range" class="form-range" name="{{form.mystery_game_mode_vr.name}}" id="{{form.mystery_game_mode_vr.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_game_mode_vr.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_game_mode_vr.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <h4>Item Difficulty:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_item_difficulty_easy.id_for_label}}" class="form-label mr-2">Easy:</label>
                 <input type="range" class="form-range" name="{{form.mystery_item_difficulty_easy.name}}" id="{{form.mystery_item_difficulty_easy.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_item_difficulty_easy.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_item_difficulty_easy.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_item_difficulty_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
                 <input type="range" class="form-range" name="{{form.mystery_item_difficulty_normal.name}}" id="{{form.mystery_item_difficulty_normal.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_item_difficulty_normal.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_item_difficulty_normal.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_item_difficulty_hard.id_for_label}}" class="form-label mr-2">Hard:</label>
                 <input type="range" class="form-range" name="{{form.mystery_item_difficulty_hard.name}}" id="{{form.mystery_item_difficulty_hard.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_item_difficulty_hard.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_item_difficulty_hard.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <h4>Enemy Difficulty:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_enemy_difficulty_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
                 <input type="range" class="form-range" name="{{form.mystery_enemy_difficulty_normal.name}}" id="{{form.mystery_enemy_difficulty_normal.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_enemy_difficulty_normal.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_enemy_difficulty_normal.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_enemy_difficulty_hard.id_for_label}}" class="form-label mr-2">Hard:</label>
                 <input type="range" class="form-range" name="{{form.mystery_enemy_difficulty_hard.name}}" id="{{form.mystery_enemy_difficulty_hard.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_enemy_difficulty_hard.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_enemy_difficulty_hard.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <h4>Tech Order:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_tech_order_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
                 <input type="range" class="form-range" name="{{form.mystery_tech_order_normal.name}}" id="{{form.mystery_tech_order_normal.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_tech_order_normal.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_tech_order_normal.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_tech_order_full_random.id_for_label}}" class="form-label mr-2">Full Random:</label>
                 <input type="range" class="form-range" name="{{form.mystery_tech_order_full_random.name}}" id="{{form.mystery_tech_order_full_random.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_tech_order_full_random.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_tech_order_full_random.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_tech_order_balanced_random.id_for_label}}" class="form-label mr-2">Balanced Random:</label>
                 <input type="range" class="form-range" name="{{form.mystery_tech_order_balanced_random.name}}" id="{{form.mystery_tech_order_balanced_random.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_tech_order_balanced_random.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_tech_order_balanced_random.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <h4>Shop Prices:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
                 <input type="range" class="form-range" name="{{form.mystery_shop_prices_normal.name}}" id="{{form.mystery_shop_prices_normal.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_shop_prices_normal.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_shop_prices_normal.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_random.id_for_label}}" class="form-label mr-2">Random:</label>
                 <input type="range" class="form-range" name="{{form.mystery_shop_prices_random.name}}" id="{{form.mystery_shop_prices_random.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_shop_prices_random.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_shop_prices_random.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_mostly_random.id_for_label}}" class="form-label mr-2">Mostly Random:</label>
                 <input type="range" class="form-range" name="{{form.mystery_shop_prices_mostly_random.name}}" id="{{form.mystery_shop_prices_mostly_random.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_shop_prices_mostly_random.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_shop_prices_mostly_random.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_free.id_for_label}}" class="form-label mr-2">Free:</label>
                 <input type="range" class="form-range" name="{{form.mystery_shop_prices_free.name}}" id="{{form.mystery_shop_prices_free.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_shop_prices_free.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.mystery_shop_prices_free.id_for_label}}_text" form="none" size="4" min="0" max="100">
               </div>
 
               <h4>Flag Probabilities:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_tab_treasures.id_for_label}}" class="form-label mr-2">Tab Treasures:</label>
                 <input type="range" class="form-range" name="{{form.mystery_tab_treasures.name}}" id="{{form.mystery_tab_treasures.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_tab_treasures.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_tab_treasures.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_unlock_magic.id_for_label}}" class="form-label mr-2">Unlocked Magic:</label>
                 <input type="range" class="form-range" name="{{form.mystery_unlock_magic.name}}" id="{{form.mystery_unlock_magic.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_unlock_magic.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_unlock_magic.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_bucket_list.id_for_label}}" class="form-label mr-2">Bucket List:</label>
                 <input type="range" class="form-range" name="{{form.mystery_bucket_list.name}}" id="{{form.mystery_bucket_list.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_bucket_list.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_bucket_list.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_chronosanity.id_for_label}}" class="form-label mr-2">Chronosanity:</label>
                 <input type="range" class="form-range" name="{{form.mystery_chronosanity.name}}" id="{{form.mystery_chronosanity.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_chronosanity.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_chronosanity.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_boss_rando.id_for_label}}" class="form-label mr-2">Boss Rando:</label>
                 <input type="range" class="form-range" name="{{form.mystery_boss_rando.name}}" id="{{form.mystery_boss_rando.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_boss_rando.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_boss_rando.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_boss_scale.id_for_label}}" class="form-label mr-2">Boss Scaling:</label>
                 <input type="range" class="form-range" name="{{form.mystery_boss_scale.name}}" id="{{form.mystery_boss_scale.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_boss_scale.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_boss_scale.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_locked_characters.id_for_label}}" class="form-label mr-2">Locked Characters:</label>
                 <input type="range" class="form-range" name="{{form.mystery_locked_characters.name}}" id="{{form.mystery_locked_characters.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_locked_characters.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_locked_characters.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_char_rando.id_for_label}}" class="form-label mr-2">Character Rando:</label>
                 <input type="range" class="form-range" name="{{form.mystery_char_rando.name}}" id="{{form.mystery_char_rando.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_char_rando.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_char_rando.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_duplicate_characters.id_for_label}}" class="form-label mr-2">Duplicate Characters:</label>
                 <input type="range" class="form-range" name="{{form.mystery_duplicate_characters.name}}" id="{{form.mystery_duplicate_characters.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_duplicate_characters.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_duplicate_characters.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_epoch_fail.id_for_label}}" class="form-label mr-2">Epoch Fail:</label>
                 <input type="range" class="form-range" name="{{form.mystery_epoch_fail.name}}" id="{{form.mystery_epoch_fail.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_epoch_fail.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_epoch_fail.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_gear_rando.id_for_label}}" class="form-label mr-2">Gear Rando:</label>
                 <input type="range" class="form-range" name="{{form.mystery_gear_rando.name}}" id="{{form.mystery_gear_rando.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_gear_rando.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_gear_rando.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_heal_rando.id_for_label}}" class="form-label mr-2">Heal Rando:</label>
                 <input type="range" class="form-range" name="{{form.mystery_heal_rando.name}}" id="{{form.mystery_heal_rando.id_for_label}}" min="0" max="100">
-                <input type="text" id="{{form.mystery_heal_rando.id_for_label}}_text" form="none" size="2">
+                <input type="number" id="{{form.mystery_heal_rando.id_for_label}}_text" form="none" size="4" min="0" max="100" class="mr-1">%
               </div>
 
             </div>

--- a/generator/templates/generator/options/mystery_tab.html
+++ b/generator/templates/generator/options/mystery_tab.html
@@ -3,175 +3,181 @@
               <h4>Game Modes:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_standard.id_for_label}}" class="form-label mr-2">Standard:</label>
-                <input type="range" class="form-range" name="{{form.mystery_game_mode_standard.name}}" id="{{form.mystery_game_mode_standard.id_for_label}}" min="0" max="100" value="75" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_game_mode_standard_text" form="none" size="1" value="75" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_game_mode_standard.name}}" id="{{form.mystery_game_mode_standard.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_game_mode_standard.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_lw.id_for_label}}" class="form-label mr-2">Lost Worlds:</label>
-                <input type="range" class="form-range" name="{{form.mystery_game_mode_lw.name}}" id="{{form.mystery_game_mode_lw.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_game_mode_lw_text" form="none" size="1" value="25" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_game_mode_lw.name}}" id="{{form.mystery_game_mode_lw.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_game_mode_lw.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_loc.id_for_label}}" class="form-label mr-2">Legacy of Cyrus:</label>
-                <input type="range" class="form-range" name="{{form.mystery_game_mode_loc.name}}" id="{{form.mystery_game_mode_loc.id_for_label}}" min="0" max="100" value="0" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_game_mode_loc_text" form="none" size="1" value="0" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_game_mode_loc.name}}" id="{{form.mystery_game_mode_loc.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_game_mode_loc.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_game_mode_ia.id_for_label}}" class="form-label mr-2">Ice Age:</label>
-                <input type="range" class="form-range" name="{{form.mystery_game_mode_ia.name}}" id="{{form.mystery_game_mode_ia.id_for_label}}" min="0" max="100" value="0" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_game_mode_ia_text" form="none" size="1" value="0" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_game_mode_ia.name}}" id="{{form.mystery_game_mode_ia.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_game_mode_ia.id_for_label}}_text" form="none" size="1">
+              </div>
+
+              <div class="form-group">
+                <label for="{{form.mystery_game_mode_vr.id_for_label}}" class="form-label mr-2">Vanilla Rando:</label>
+                <input type="range" class="form-range" name="{{form.mystery_game_mode_vr.name}}" id="{{form.mystery_game_mode_vr.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_game_mode_vr.id_for_label}}_text" form="none" size="1">
               </div>
 
               <h4>Item Difficulty:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_item_difficulty_easy.id_for_label}}" class="form-label mr-2">Easy:</label>
-                <input type="range" class="form-range" name="{{form.mystery_item_difficulty_easy.name}}" id="{{form.mystery_item_difficulty_easy.id_for_label}}" min="0" max="100" value="15" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_item_difficulty_easy_text" form="none" size="1" value="15" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_item_difficulty_easy.name}}" id="{{form.mystery_item_difficulty_easy.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_item_difficulty_easy.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_item_difficulty_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
-                <input type="range" class="form-range" name="{{form.mystery_item_difficulty_normal.name}}" id="{{form.mystery_item_difficulty_normal.id_for_label}}" min="0" max="100" value="70" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_item_difficulty_normal_text" form="none" size="1" value="70" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_item_difficulty_normal.name}}" id="{{form.mystery_item_difficulty_normal.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_item_difficulty_normal.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_item_difficulty_hard.id_for_label}}" class="form-label mr-2">Hard:</label>
-                <input type="range" class="form-range" name="{{form.mystery_item_difficulty_hard.name}}" id="{{form.mystery_item_difficulty_hard.id_for_label}}" min="0" max="100" value="15" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_item_difficulty_hard_text" form="none" size="1" value="15" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_item_difficulty_hard.name}}" id="{{form.mystery_item_difficulty_hard.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_item_difficulty_hard.id_for_label}}_text" form="none" size="1">
               </div>
 
               <h4>Enemy Difficulty:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_enemy_difficulty_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
-                <input type="range" class="form-range" name="{{form.mystery_enemy_difficulty_normal.name}}" id="{{form.mystery_enemy_difficulty_normal.id_for_label}}" min="0" max="100" value="75" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_enemy_difficulty_normal_text" form="none" size="1" value="75" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_enemy_difficulty_normal.name}}" id="{{form.mystery_enemy_difficulty_normal.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_enemy_difficulty_normal.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_enemy_difficulty_hard.id_for_label}}" class="form-label mr-2">Hard:</label>
-                <input type="range" class="form-range" name="{{form.mystery_enemy_difficulty_hard.name}}" id="{{form.mystery_enemy_difficulty_hard.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_enemy_difficulty_hard_text" form="none" size="1" value="25" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_enemy_difficulty_hard.name}}" id="{{form.mystery_enemy_difficulty_hard.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_enemy_difficulty_hard.id_for_label}}_text" form="none" size="1">
               </div>
 
               <h4>Tech Order:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_tech_order_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
-                <input type="range" class="form-range" name="{{form.mystery_tech_order_normal.name}}" id="{{form.mystery_tech_order_normal.id_for_label}}" min="0" max="100" value="10" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_tech_order_normal_text" form="none" size="1" value="10" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_tech_order_normal.name}}" id="{{form.mystery_tech_order_normal.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_tech_order_normal.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_tech_order_full_random.id_for_label}}" class="form-label mr-2">Full Random:</label>
-                <input type="range" class="form-range" name="{{form.mystery_tech_order_full_random.name}}" id="{{form.mystery_tech_order_full_random.id_for_label}}" min="0" max="100" value="80" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_tech_order_full_random_text" form="none" size="1" value="80" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_tech_order_full_random.name}}" id="{{form.mystery_tech_order_full_random.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_tech_order_full_random.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_tech_order_balanced_random.id_for_label}}" class="form-label mr-2">Balanced Random:</label>
-                <input type="range" class="form-range" name="{{form.mystery_tech_order_balanced_random.name}}" id="{{form.mystery_tech_order_balanced_random.id_for_label}}" min="0" max="100" value="10" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_tech_order_balanced_random_text" form="none" size="1" value="10" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_tech_order_balanced_random.name}}" id="{{form.mystery_tech_order_balanced_random.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_tech_order_balanced_random.id_for_label}}_text" form="none" size="1">
               </div>
 
               <h4>Shop Prices:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_normal.id_for_label}}" class="form-label mr-2">Normal:</label>
-                <input type="range" class="form-range" name="{{form.mystery_shop_prices_normal.name}}" id="{{form.mystery_shop_prices_normal.id_for_label}}" min="0" max="100" value="70" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_shop_prices_normal_text" form="none" size="1" value="70" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_shop_prices_normal.name}}" id="{{form.mystery_shop_prices_normal.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_shop_prices_normal.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_random.id_for_label}}" class="form-label mr-2">Random:</label>
-                <input type="range" class="form-range" name="{{form.mystery_shop_prices_random.name}}" id="{{form.mystery_shop_prices_random.id_for_label}}" min="0" max="100" value="10" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_shop_prices_random_text" form="none" size="1" value="10" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_shop_prices_random.name}}" id="{{form.mystery_shop_prices_random.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_shop_prices_random.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_mostly_random.id_for_label}}" class="form-label mr-2">Mostly Random:</label>
-                <input type="range" class="form-range" name="{{form.mystery_shop_prices_mostly_random.name}}" id="{{form.mystery_shop_prices_mostly_random.id_for_label}}" min="0" max="100" value="10" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_shop_prices_mostly_random_text" form="none" size="1" value="10" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_shop_prices_mostly_random.name}}" id="{{form.mystery_shop_prices_mostly_random.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_shop_prices_mostly_random.id_for_label}}_text" form="none" size="1">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_shop_prices_free.id_for_label}}" class="form-label mr-2">Free:</label>
-                <input type="range" class="form-range" name="{{form.mystery_shop_prices_free.name}}" id="{{form.mystery_shop_prices_free.id_for_label}}" min="0" max="100" value="10" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_shop_prices_free_text" form="none" size="1" value="10" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_shop_prices_free.name}}" id="{{form.mystery_shop_prices_free.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_shop_prices_free.id_for_label}}_text" form="none" size="1">
               </div>
 
               <h4>Flag Probabilities:</h4>
               <div class="form-group">
                 <label for="{{form.mystery_tab_treasures.id_for_label}}" class="form-label mr-2">Tab Treasures:</label>
-                <input type="range" class="form-range" name="{{form.mystery_tab_treasures.name}}" id="{{form.mystery_tab_treasures.id_for_label}}" min="0" max="100" value="10" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_tab_treasures_text" form="none" size="2" value="10%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_tab_treasures.name}}" id="{{form.mystery_tab_treasures.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_tab_treasures.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_unlock_magic.id_for_label}}" class="form-label mr-2">Unlocked Magic:</label>
-                <input type="range" class="form-range" name="{{form.mystery_unlock_magic.name}}" id="{{form.mystery_unlock_magic.id_for_label}}" min="0" max="100" value="50" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_unlock_magic_text" form="none" size="2" value="50%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_unlock_magic.name}}" id="{{form.mystery_unlock_magic.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_unlock_magic.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_bucket_list.id_for_label}}" class="form-label mr-2">Bucket List:</label>
-                <input type="range" class="form-range" name="{{form.mystery_bucket_list.name}}" id="{{form.mystery_bucket_list.id_for_label}}" min="0" max="100" value="15" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_bucket_list_text" form="none" size="2" value="15%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_bucket_list.name}}" id="{{form.mystery_bucket_list.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_bucket_list.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_chronosanity.id_for_label}}" class="form-label mr-2">Chronosanity:</label>
-                <input type="range" class="form-range" name="{{form.mystery_chronosanity.name}}" id="{{form.mystery_chronosanity.id_for_label}}" min="0" max="100" value="30" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_chronosanity_text" form="none" size="2" value="30%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_chronosanity.name}}" id="{{form.mystery_chronosanity.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_chronosanity.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_boss_rando.id_for_label}}" class="form-label mr-2">Boss Rando:</label>
-                <input type="range" class="form-range" name="{{form.mystery_boss_rando.name}}" id="{{form.mystery_boss_rando.id_for_label}}" min="0" max="100" value="50" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_boss_rando_text" form="none" size="2" value="50%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_boss_rando.name}}" id="{{form.mystery_boss_rando.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_boss_rando.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_boss_scale.id_for_label}}" class="form-label mr-2">Boss Scaling:</label>
-                <input type="range" class="form-range" name="{{form.mystery_boss_scale.name}}" id="{{form.mystery_boss_scale.id_for_label}}" min="0" max="100" value="30" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_boss_scale_text" form="none" size="2" value="30%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_boss_scale.name}}" id="{{form.mystery_boss_scale.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_boss_scale.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_locked_characters.id_for_label}}" class="form-label mr-2">Locked Characters:</label>
-                <input type="range" class="form-range" name="{{form.mystery_locked_characters.name}}" id="{{form.mystery_locked_characters.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_locked_characters_text" form="none" size="2" value="25%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_locked_characters.name}}" id="{{form.mystery_locked_characters.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_locked_characters.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_char_rando.id_for_label}}" class="form-label mr-2">Character Rando:</label>
-                <input type="range" class="form-range" name="{{form.mystery_char_rando.name}}" id="{{form.mystery_char_rando.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_char_rando_text" form="none" size="2" value="25%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_char_rando.name}}" id="{{form.mystery_char_rando.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_char_rando.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_duplicate_characters.id_for_label}}" class="form-label mr-2">Duplicate Characters:</label>
-                <input type="range" class="form-range" name="{{form.mystery_duplicate_characters.name}}" id="{{form.mystery_duplicate_characters.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_duplicate_characters_text" form="none" size="2" value="25%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_duplicate_characters.name}}" id="{{form.mystery_duplicate_characters.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_duplicate_characters.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_epoch_fail.id_for_label}}" class="form-label mr-2">Epoch Fail:</label>
-                <input type="range" class="form-range" name="{{form.mystery_epoch_fail.name}}" id="{{form.mystery_epoch_fail.id_for_label}}" min="0" max="100" value="50" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_epoch_fail_text" form="none" size="2" value="50%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_epoch_fail.name}}" id="{{form.mystery_epoch_fail.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_epoch_fail.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_gear_rando.id_for_label}}" class="form-label mr-2">Gear Rando:</label>
-                <input type="range" class="form-range" name="{{form.mystery_gear_rando.name}}" id="{{form.mystery_gear_rando.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_gear_rando_text" form="none" size="2" value="25%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_gear_rando.name}}" id="{{form.mystery_gear_rando.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_gear_rando.id_for_label}}_text" form="none" size="2">
               </div>
 
               <div class="form-group">
                 <label for="{{form.mystery_heal_rando.id_for_label}}" class="form-label mr-2">Heal Rando:</label>
-                <input type="range" class="form-range" name="{{form.mystery_heal_rando.name}}" id="{{form.mystery_heal_rando.id_for_label}}" min="0" max="100" value="25" oninput="updateMysterySettings()" onchange="updateMysterySettings()" >
-                <input type="text" id="mystery_heal_rando_text" form="none" size="2" value="25%" readonly>
+                <input type="range" class="form-range" name="{{form.mystery_heal_rando.name}}" id="{{form.mystery_heal_rando.id_for_label}}" min="0" max="100">
+                <input type="text" id="{{form.mystery_heal_rando.id_for_label}}_text" form="none" size="2">
               </div>
 
             </div>

--- a/generator/templates/generator/options/presets.html
+++ b/generator/templates/generator/options/presets.html
@@ -1,0 +1,8 @@
+      <div class="border border-primary rounded p-2">
+        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="resetAll()">Reset All</button>
+        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetRace()">Race</button>
+        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetNewPlayer()">New Player</button>
+        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLostWorlds()">Lost Worlds</button>
+        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetHard()">Hard</button>
+        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLegacyOfCyrus()">Legacy of Cyrus</button>
+      </div>

--- a/generator/templates/generator/options/presets.html
+++ b/generator/templates/generator/options/presets.html
@@ -2,13 +2,13 @@
 
         <div class="form-row">
           <div class="col">
-            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="resetAll()">Reset All</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['race'])">Race</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['new_player'])">New Player</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['lost_worlds'])">Lost Worlds</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['hard'])">Hard</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['legacy_of_cyrus'])">Legacy of Cyrus</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_load_preset_btn" onclick="loadSelectedPreset()">Upload Preset</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_reset_all_btn">Reset All</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_race">Race</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_new_player">New Player</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_lost_worlds">Lost Worlds</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_hard">Hard</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_legacy_of_cyrus">Legacy of Cyrus</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_load_preset_btn">Upload Preset</button>
           </div>
 
           <div class="w-100"></div>
@@ -25,7 +25,7 @@
               <div class="input-group-prepend">
                 <div class="input-group-text">Upload Preset</div>
               </div>
-              <input type="file" accept="application/JSON" class="form-control-file form-control" id="{{form.preset_file.id_for_label}}" name="{{form.preset_file.name}}" onchange="loadSelectedPreset()">
+              <input type="file" accept="application/JSON" class="form-control-file form-control" id="{{form.preset_file.id_for_label}}" name="{{form.preset_file.name}}">
             </div>
           </div>
           <div class="w-100"></div>

--- a/generator/templates/generator/options/presets.html
+++ b/generator/templates/generator/options/presets.html
@@ -1,8 +1,37 @@
       <div class="border border-primary rounded p-2">
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="resetAll()">Reset All</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetRace()">Race</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetNewPlayer()">New Player</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLostWorlds()">Lost Worlds</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetHard()">Hard</button>
-        <button class="btn btn-primary mt-1 mb-1" type="button" onclick="presetLegacyOfCyrus()">Legacy of Cyrus</button>
+
+        <div class="form-row">
+          <div class="col">
+            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="resetAll()">Reset All</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['race'])">Race</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['new_player'])">New Player</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['lost_worlds'])">Lost Worlds</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['hard'])">Hard</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" onclick="applyPreset(presetsMap['legacy_of_cyrus'])">Legacy of Cyrus</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_load_preset_btn" onclick="loadSelectedPreset()">Upload Preset</button>
+          </div>
+
+          <div class="w-100"></div>
+
+          <div class="col p-2">
+            <div id="id_preset_metadata"></div>
+          </div>
+
+          <div class="w-100"></div>
+
+          <!-- Preset upload -->
+          <div class="col align-self-end collapse custom-preset-collapse">
+            <div class="input-group mb-2">
+              <div class="input-group-prepend">
+                <div class="input-group-text">Upload Preset</div>
+              </div>
+              <input type="file" accept="application/JSON" class="form-control-file form-control" id="{{form.preset_file.id_for_label}}" name="{{form.preset_file.name}}" onchange="loadSelectedPreset()">
+            </div>
+          </div>
+          <div class="w-100"></div>
+          <div class="col">
+            <div class="bg-danger" id="id_invalid_preset_file"></div>
+          </div>
+        </div>
+
       </div>

--- a/generator/templates/generator/options/presets.html
+++ b/generator/templates/generator/options/presets.html
@@ -2,13 +2,13 @@
 
         <div class="form-row">
           <div class="col">
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_reset_all_btn">Reset All</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_race">Race</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_new_player">New Player</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_lost_worlds">Lost Worlds</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_hard">Hard</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_legacy_of_cyrus">Legacy of Cyrus</button>
-            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_load_preset_btn">Upload Preset</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_reset_all_btn" title="Reset all selections to default settings.">Reset All</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_race" title="Apply settings for 'Race' preset.">Race</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_new_player" title="Apply settings for 'New Player' preset.">New Player</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_lost_worlds" title="Apply settings for 'Lost Worlds' preset.">Lost Worlds</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_hard" title="Apply settings for 'Hard' preset.">Hard</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_preset_btn_legacy_of_cyrus" title="Apply settings for 'Legacy of Cyrus' preset.">Legacy of Cyrus</button>
+            <button class="btn btn-primary mt-1 mb-1" type="button" id="id_load_preset_btn" title="Upload your own custom preset JSON file.">Upload Preset</button>
           </div>
 
           <div class="w-100"></div>

--- a/generator/templates/generator/options/tabs_tab.html
+++ b/generator/templates/generator/options/tabs_tab.html
@@ -2,32 +2,32 @@
             <div class="border border-primary rounded p-2 mb-3">
               <div class="form-group">
                 <label for="{{form.power_tab_min.id_for_label}}" class="form-label mr-2">Power Tab Min:</label>
-                <input type="range" class="form-range" name="{{form.power_tab_min.name}}" id="{{form.power_tab_min.id_for_label}}" min="1" max="9" value="2" oninput="updateAllTabValues()" onchange="updateAllTabValues()" >
-                <input type="text" id="power_tab_min_text" form="none" size="1" value="2" readonly>
+                <input type="range" class="form-range" name="{{form.power_tab_min.name}}" id="{{form.power_tab_min.id_for_label}}" min="1" max="9">
+                <input type="text" id="{{form.power_tab_min.id_for_label}}_text" form="none" size="1">
               </div>
               <div class="form-group">
                 <label for="{{form.power_tab_max.id_for_label}}" class="form-label mr-2">Power Tab Max:</label>
-                <input type="range" class="form-range" name="{{form.power_tab_max.name}}" id="{{form.power_tab_max.id_for_label}}" min="1" max="9" value="4" oninput="updateAllTabValues(true)" onchange="updateAllTabValues(true)" >
-                <input type="text" id="power_tab_max_text" form="none" size="1" value="4" readonly>
+                <input type="range" class="form-range" name="{{form.power_tab_max.name}}" id="{{form.power_tab_max.id_for_label}}" min="1" max="9">
+                <input type="text" id="{{form.power_tab_max.id_for_label}}_text" form="none" size="1">
               </div>
               <div class="form-group">
                 <label for="{{form.magic_tab_min.id_for_label}}" class="form-label mr-2">Magic Tab Min:</label>
-                <input type="range" class="form-range" name="{{form.magic_tab_min.name}}" id="{{form.magic_tab_min.id_for_label}}" min="1" max="9" value="1" oninput="updateAllTabValues()" onchange="updateAllTabValues()" >
-                <input type="text" id="magic_tab_min_text" form="none" size="1" value="1" readonly>
+                <input type="range" class="form-range" name="{{form.magic_tab_min.name}}" id="{{form.magic_tab_min.id_for_label}}" min="1" max="9">
+                <input type="text" id="{{form.magic_tab_min.id_for_label}}_text" form="none" size="1">
               </div>
               <div class="form-group">
                 <label for="{{form.magic_tab_max.id_for_label}}" class="form-label mr-2">Magic Tab Max:</label>
-                <input type="range" class="form-range" name="{{form.magic_tab_max.name}}" id="{{form.magic_tab_max.id_for_label}}" min="1" max="9" value="3" oninput="updateAllTabValues(true)" onchange="updateAllTabValues(true)" >
-                <input type="text" id="magic_tab_max_text" form="none" size="1" value="3" readonly>
+                <input type="range" class="form-range" name="{{form.magic_tab_max.name}}" id="{{form.magic_tab_max.id_for_label}}" min="1" max="9">
+                <input type="text" id="{{form.magic_tab_max.id_for_label}}_text" form="none" size="1">
               </div>
               <div class="form-group">
                 <label for="{{form.speed_tab_min.id_for_label}}" class="form-label mr-2">Speed Tab Min:</label>
-                <input type="range" class="form-range" name="{{form.speed_tab_min.name}}" id="{{form.speed_tab_min.id_for_label}}" min="1" max="9" value="1" oninput="updateAllTabValues()" onchange="updateAllTabValues()" >
-                <input type="text" id="speed_tab_min_text" form="none" size="1" value="1" readonly>
+                <input type="range" class="form-range" name="{{form.speed_tab_min.name}}" id="{{form.speed_tab_min.id_for_label}}" min="1" max="9">
+                <input type="text" id="{{form.speed_tab_min.id_for_label}}_text" form="none" size="1">
               </div>
               <div class="form-group">
                 <label for="{{form.speed_tab_max.id_for_label}}" class="form-label mr-2">Speed Tab Max:</label>
-                <input type="range" class="form-range" name="{{form.speed_tab_max.name}}" id="{{form.speed_tab_max.id_for_label}}" min="1" max="9" value="1" oninput="updateAllTabValues(true)" onchange="updateAllTabValues(true)" >
-                <input type="text" id="speed_tab_max_text" form="none" size="1" value="1" readonly>
+                <input type="range" class="form-range" name="{{form.speed_tab_max.name}}" id="{{form.speed_tab_max.id_for_label}}" min="1" max="9">
+                <input type="text" id="{{form.speed_tab_max.id_for_label}}_text" form="none" size="1">
               </div>
             </div>

--- a/generator/templates/generator/options/tabs_tab.html
+++ b/generator/templates/generator/options/tabs_tab.html
@@ -3,31 +3,31 @@
               <div class="form-group">
                 <label for="{{form.power_tab_min.id_for_label}}" class="form-label mr-2">Power Tab Min:</label>
                 <input type="range" class="form-range" name="{{form.power_tab_min.name}}" id="{{form.power_tab_min.id_for_label}}" min="1" max="9">
-                <input type="text" id="{{form.power_tab_min.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.power_tab_min.id_for_label}}_text" form="none" size="2" min="1" max="9">
               </div>
               <div class="form-group">
                 <label for="{{form.power_tab_max.id_for_label}}" class="form-label mr-2">Power Tab Max:</label>
                 <input type="range" class="form-range" name="{{form.power_tab_max.name}}" id="{{form.power_tab_max.id_for_label}}" min="1" max="9">
-                <input type="text" id="{{form.power_tab_max.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.power_tab_max.id_for_label}}_text" form="none" size="2" min="1" max="9">
               </div>
               <div class="form-group">
                 <label for="{{form.magic_tab_min.id_for_label}}" class="form-label mr-2">Magic Tab Min:</label>
                 <input type="range" class="form-range" name="{{form.magic_tab_min.name}}" id="{{form.magic_tab_min.id_for_label}}" min="1" max="9">
-                <input type="text" id="{{form.magic_tab_min.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.magic_tab_min.id_for_label}}_text" form="none" size="2" min="1" max="9">
               </div>
               <div class="form-group">
                 <label for="{{form.magic_tab_max.id_for_label}}" class="form-label mr-2">Magic Tab Max:</label>
                 <input type="range" class="form-range" name="{{form.magic_tab_max.name}}" id="{{form.magic_tab_max.id_for_label}}" min="1" max="9">
-                <input type="text" id="{{form.magic_tab_max.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.magic_tab_max.id_for_label}}_text" form="none" size="2" min="1" max="9">
               </div>
               <div class="form-group">
                 <label for="{{form.speed_tab_min.id_for_label}}" class="form-label mr-2">Speed Tab Min:</label>
                 <input type="range" class="form-range" name="{{form.speed_tab_min.name}}" id="{{form.speed_tab_min.id_for_label}}" min="1" max="9">
-                <input type="text" id="{{form.speed_tab_min.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.speed_tab_min.id_for_label}}_text" form="none" size="2" min="1" max="9">
               </div>
               <div class="form-group">
                 <label for="{{form.speed_tab_max.id_for_label}}" class="form-label mr-2">Speed Tab Max:</label>
                 <input type="range" class="form-range" name="{{form.speed_tab_max.name}}" id="{{form.speed_tab_max.id_for_label}}" min="1" max="9">
-                <input type="text" id="{{form.speed_tab_max.id_for_label}}_text" form="none" size="1">
+                <input type="number" id="{{form.speed_tab_max.id_for_label}}_text" form="none" size="2" min="1" max="9">
               </div>
             </div>

--- a/generator/templates/generator/seed/spoiler_log_section.html
+++ b/generator/templates/generator/seed/spoiler_log_section.html
@@ -1,7 +1,8 @@
 
         <div class="pt-2">
           <input type="button" class="btn btn-primary" id="spoiler_log_button" value="Show Spoiler Log" data-toggle="collapse" data-target="#spoiler_section" aria-expanded="false" aria-controls="spoiler_section">
-	  <a class="btn btn-primary" href="{% url 'generator:spoiler_log' share_id %}" target="_blank">Download Spoiler Log</a>
+          <a class="btn btn-primary" href="{% url 'generator:spoiler_log' share_id %}" target="_blank">Download Spoiler Log</a>
+          <a class="btn btn-primary" href="{% url 'generator:json_spoiler_log' share_id %}" target="_blank">Download JSON Spoiler Log</a>
         </div>
 
         <div class="tab-content collapse border border-primary rounded p-3" id="spoiler_section">

--- a/generator/tests.py
+++ b/generator/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/generator/urls.py
+++ b/generator/urls.py
@@ -7,6 +7,11 @@ app_name = 'generator'
 
 urlpatterns = [
     path('', TemplateView.as_view(template_name="generator/index.html"), name='index'),
+    path('download/preset/', views.DownloadPresetView.as_view(), name='export_preset'),
+    path('download/spoiler_log/<str:share_id>.txt', views.DownloadSpoilerLogView.as_view(), name='spoiler_log'),
+    path(
+        'download/spoiler_log/<str:share_id>.json', views.DownloadJSONSpoilerLogView.as_view(), name='json_spoiler_log'
+    ),
     path('tracker/', TemplateView.as_view(template_name="tracker/tracker.html"), name='tracker'),
     path('options/', views.OptionsView.as_view(), name='options'),
     path('generate-rom/', views.GenerateView.as_view(), name='generate'),
@@ -14,6 +19,4 @@ urlpatterns = [
     path('practice/<str:share_id>/', views.PracticeSeedView.as_view(), name='practice'),
     path('seedimg/<str:share_id>.png', views.SeedImageView.as_view(), name='seedimg'),
     path('seed/', views.DownloadSeedView.as_view(), name='seed'),
-    path('spoiler_log/<str:share_id>.txt', views.DownloadSpoilerLogView.as_view(), name='spoiler_log'),
-    path('spoiler_log/<str:share_id>.json', views.DownloadJSONSpoilerLogView.as_view(), name='json_spoiler_log'),
 ]

--- a/generator/views.py
+++ b/generator/views.py
@@ -58,6 +58,7 @@ class OptionsView(View):
         context = {
             'form': form,
             'enums_map': RandomizerInterface.get_enums_map(),
+            'forced_flags_json': RandomizerInterface.get_forced_flags_json(),
             'inv_enums_map': RandomizerInterface.get_inv_enums_map(),
             'obhint_map': RandomizerInterface.get_obhint_map(),
             'presets_map': RandomizerInterface.get_presets_map(),

--- a/generator/views.py
+++ b/generator/views.py
@@ -91,6 +91,18 @@ class GenerateView(FormView):
         return render(self.request, 'generator/error.html', {'error_text': buffer.getvalue()}, status=404)
 
 
+class DownloadPresetView(GenerateView):
+    def form_valid(self, form):
+        contents = form.cleaned_data['preset']
+        preset = json.loads(contents)
+        response = HttpResponse(content_type='application/json')
+        response.write(contents)
+
+        name = preset.get('metadata', {}).get('name', 'preset').lower().replace(' ', '-')
+        response['Content-Disposition'] = f"attachment; filename={name}.preset.json"
+        return response
+
+
 class ShareLinkView(View):
     """
     Handle a share link for a previously generated game.

--- a/generator/views.py
+++ b/generator/views.py
@@ -19,7 +19,6 @@ import io
 import json
 import pickle
 import random
-import base64
 
 from typing import Any, Dict
 
@@ -53,7 +52,15 @@ class OptionsView(View):
     @classmethod
     def get(cls, request):
         form = GenerateForm()
-        context = {'form': form}
+        gameflags_map = RandomizerInterface.get_gameflags_map()
+        obhint_map = RandomizerInterface.get_obhint_map()
+        settings_defaults_json = RandomizerInterface.get_settings_defaults_json()
+        context = {
+            'form': form,
+            'gameflags_map': gameflags_map,
+            'obhint_map': obhint_map,
+            'settings_defaults_json': settings_defaults_json,
+        }
         return render(request, 'generator/options.html', context)
 
 
@@ -238,7 +245,13 @@ class PracticeSeedView(View):
         return redirect('/share/' + game.share_id)
 
 
-hashsymbols = base64.b64decode('R0lGODlhYAAIAPEDABggKIiQkPj4+AAAACH5BAUAAAMALAAAAABgAAgAQALTBIYpNwbSVkIvnCPkpMv6LFiJwxjNdQUhA4Iioo3qY8xx9AxLF0LcHOkFhriJSiUEIDMWGqcSOh6WIuUtMishSzwVVlKCIpuG0GBpZqo7R4lQ2gJxK2Wur6HjVkfdk3zilEeSUwHUMHbR8gLGyMBXw2QV8xAJ0eP4yBZXhXjGVhGk8baigGl1QWEok2FSBvKzU9Zm4+jQc2k1tEIDSano+idT1agV6Wtxh9XUxvpUqtQEIcm5QDcqYvNCgWPmjCe9EY6nhCl+ireBQlHrMEIy4j5QAAA7')
+hashsymbols = base64.b64decode(
+    'R0lGODlhYAAIAPEDABggKIiQkPj4+AAAACH5BAUAAAMALAAAAABgAAgAQALTBIYpNwbSVkIvnCPkpMv6LFiJwxjNdQUhA4Iioo3qY8xx'
+    '9AxLF0LcHOkFhriJSiUEIDMWGqcSOh6WIuUtMishSzwVVlKCIpuG0GBpZqo7R4lQ2gJxK2Wur6HjVkfdk3zilEeSUwHUMHbR8gLGyMBX'
+    'w2QV8xAJ0eP4yBZXhXjGVhGk8baigGl1QWEok2FSBvKzU9Zm4+jQc2k1tEIDSano+idT1agV6Wtxh9XUxvpUqtQEIcm5QDcqYvNCgWPm'
+    'jCe9EY6nhCl+ireBQlHrMEIy4j5QAAA7'
+)
+
 
 class SeedImageView(View):
     """
@@ -260,18 +273,20 @@ class SeedImageView(View):
             game.save()
 
         rgen = random.Random(share_id)
-        img = Image.new('RGB', (200,200))
+        img = Image.new('RGB', (200, 200))
 
         d = ImageDraw.Draw(img)
         squaresize = 50
-        for x in range(0,200,squaresize):
+        for x in range(0, 200, squaresize):
             for y in range(0, 200, squaresize):
                 # Draw a square in a random color
-                d.polygon([(x,y),(x+squaresize,y),(x+squaresize,y+squaresize),(x,y+squaresize)],
-                        fill=(rgen.randint(0,31)*8, rgen.randint(0,31)*8, rgen.randint(0,31)*8))
+                d.polygon(
+                    [(x, y), (x+squaresize, y), (x+squaresize, y+squaresize), (x, y+squaresize)],
+                    fill=(rgen.randint(0, 31)*8, rgen.randint(0, 31)*8, rgen.randint(0, 31)*8)
+                )
 
         # make a black box to put symbols onto
-        d.polygon([(2,85),(198,85),(198,115),(2,115)], fill=(0,0,0))
+        d.polygon([(2, 85), (198, 85), (198, 115), (2, 115)], fill=(0, 0, 0))
 
         # put seed hash symbols into box
         symbols = Image.open(io.BytesIO(hashsymbols))
@@ -280,8 +295,8 @@ class SeedImageView(View):
             idx = int.from_bytes(byte, 'big') - 0x20
             if idx > 0x9:
                 idx = idx - 0x4
-            symb = symbols.resize((24,24), box=(8*idx,0,8*idx+8,8))
-            img.paste(symb, (4+n*24,88))
+            symb = symbols.resize((24, 24), box=(8*idx, 0, 8*idx+8, 8))
+            img.paste(symb, (4+n*24, 88))
 
         with io.BytesIO() as f:
             img.save(f, 'PNG')

--- a/generator/views.py
+++ b/generator/views.py
@@ -55,14 +55,13 @@ class OptionsView(View):
     @classmethod
     def get(cls, request):
         form = GenerateForm()
-        gameflags_map = RandomizerInterface.get_gameflags_map()
-        obhint_map = RandomizerInterface.get_obhint_map()
-        settings_defaults_json = RandomizerInterface.get_settings_defaults_json()
         context = {
             'form': form,
-            'gameflags_map': gameflags_map,
-            'obhint_map': obhint_map,
-            'settings_defaults_json': settings_defaults_json,
+            'enums_map': RandomizerInterface.get_enums_map(),
+            'inv_enums_map': RandomizerInterface.get_inv_enums_map(),
+            'obhint_map': RandomizerInterface.get_obhint_map(),
+            'presets_map': RandomizerInterface.get_presets_map(),
+            'settings_defaults_json': RandomizerInterface.get_settings_defaults_json(),
         }
         return render(request, 'generator/options.html', context)
 

--- a/generator/views.py
+++ b/generator/views.py
@@ -201,9 +201,9 @@ class DownloadSpoilerLogView(View):
         if not game.race_seed:
             spoiler_log = RandomizerInterface.get_spoiler_log(
                 pickle.loads(game.configuration), pickle.loads(game.settings), game.seed_hash)
-            file_name = 'spoiler_log_' + share_id + '.txt'
+            file_name = f"spoiler_log_{share_id}.txt"
             response = HttpResponse(content_type='text/plain')
-            response['Content-Disposition'] = 'attachment; filename=%s' % file_name
+            response['Content-Disposition'] = f"attachment; filename={file_name}"
             response.write(spoiler_log.getvalue())
             return response
         else:
@@ -222,13 +222,16 @@ class DownloadJSONSpoilerLogView(View):
         except Game.DoesNotExist:
             return render(request, 'generator/error.html', {'error_text': 'Seed does not exist.'}, status=404)
 
-        response = HttpResponse(content_type='application/json')
+        file_name = f"spoiler_log_{share_id}.json"
+        contents = b'{"cheating": "not_allowed"}'
         if not game.race_seed:
             spoiler_log = RandomizerInterface.get_json_spoiler_log(
                 pickle.loads(game.configuration), pickle.loads(game.settings), game.seed_hash)
-            response.write(spoiler_log.getvalue())
-        else:
-            response.write(b'{"cheating": "not_allowed"}')
+            contents = spoiler_log.getvalue()
+
+        response = HttpResponse(content_type='application/json')
+        response.write(contents)
+        response['Content-Disposition'] = f"attachment; filename={file_name}"
         return response
 
 
@@ -243,7 +246,7 @@ class PracticeSeedView(View):
         except InvalidGameIdException as e:
             return render(request, 'generator/error.html', {'error_text': str(e)}, status=404)
         except InvalidSettingsException as e:
-            return render(request, 'generator/error.html', {'error_text': str(e)}, status=404)
+            return render(request, 'generator/error.html', {'error_text': str(e)}, status=400)
 
         return redirect('/share/' + game.share_id)
 

--- a/generator/views.py
+++ b/generator/views.py
@@ -20,11 +20,14 @@ import json
 import pickle
 import random
 
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 
 # Other libraries
 import nanoid
 from PIL import Image, ImageDraw
+
+if TYPE_CHECKING:
+    from django.core.files.uploadfile import UploadedFile
 
 
 class InvalidRomException(Exception):
@@ -125,7 +128,7 @@ class DownloadSeedView(FormView):
     form_class = RomForm
 
     @classmethod
-    def read_and_validate_rom_file(cls, rom_file: bytearray):
+    def read_and_validate_rom_file(cls, rom_file: 'UploadedFile'):
         """
         Read and validate the user's ROM file.
 
@@ -134,7 +137,7 @@ class DownloadSeedView(FormView):
         is too large to be a valid ROM file.
 
         :param rom_file: File object containing a user's ROM
-        :return: bytearray containing ROM data
+        :return: UploadedFile containing ROM data (bytearray)
         """
         # Validate that the file isn't too large to be a CT ROM.
         # Don't waste time reading it if it's not a CT ROM.
@@ -390,7 +393,7 @@ def get_cosmetics(request: HttpRequest) -> Dict[str, Dict[str, Any]]:
     :param: request: HTTP request object passed from view to read cookie.
     :return: Nested dictionary mapping of cosmetic options
     """
-    cosmetics = {
+    cosmetics: Dict[str, Dict[str, Any]] = {
         # general cosmetics
         'reduce_flashes': {'default': False, 'type': 'checked'},
         'quiet_mode': {'default': False, 'type': 'checked'},

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ctjot_web_generator",
+  "description": "This project is a web interface for the Chrono Trigger: Jets of Time randomizer.",
+  "dependencies": {
+    "bootstrap": "^4.3.1",
+    "bootstrap4-toggle": "^3.6.1",
+    "bootstrap-select": "^1.13.9",
+    "jquery": "^3.4.1",
+    "js-cookie": "^3.0.5",
+    "popper.js": "^1.14.7"
+  },
+  "devDependencies": {
+    "eslint": "^8.49.0"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+line-length = 119
+skip_string_normalization = true
+
+[tool.mypy]
+disable_error_code = "annotation-unchecked"
+ignore_missing_imports = true
+exclude = [
+  "^jetsoftime",
+  "^generator/migrations"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-asgiref==3.5.2
-Django==4.1.5
-django-cors-headers==3.13.0
-gunicorn==20.1.0
+asgiref==3.7.2
+Django==4.1.11
+django-cors-headers==3.14.0
+gunicorn==21.2.0
 nanoid==2.0.0
-Pillow==9.3.0
-psycopg2-binary==2.9.5
-sqlparse==0.4.2
-tzdata==2021.5
+Pillow==9.5.0
+psycopg2-binary==2.9.7
+sqlparse==0.4.4
+tzdata==2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
-asgiref==3.7.2
-Django==4.1.11
-django-cors-headers==3.14.0
-gunicorn==21.2.0
-nanoid==2.0.0
-Pillow==9.5.0
-psycopg2-binary==2.9.7
-sqlparse==0.4.4
-tzdata==2023.3
+-c constraints.txt
+Django
+django-cors-headers
+gunicorn
+nanoid
+Pillow
+psycopg2-binary

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-flake8>=6.1,<7.0
+flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+flake8>=6.1,<7.0

--- a/tools/spoiler_log_dump.py
+++ b/tools/spoiler_log_dump.py
@@ -8,7 +8,7 @@ import sqlite3
 from sqlite3 import Error
 import sys
 
-# Add the randomizer to the system path here. 
+# Add the randomizer to the system path here.
 # Use the path within the web generator container.
 sys.path.append('/home/ctjot/web/jetsoftime/sourcefiles')
 
@@ -30,7 +30,7 @@ def create_connection() -> sqlite3.Connection:
             password = os.environ['POSTGRES_PASSWORD']
             host = os.environ['SQL_HOST']
             port = os.environ['SQL_PORT']
-            conn = psycopg2.connect(database = database, user = user, password = password, host = host, port = port)
+            conn = psycopg2.connect(database=database, user=user, password=password, host=host, port=port)
         else:
             # Not using Postgres.  Try to fall back to sqlite.
             conn = sqlite3.connect('./db.sqlite3')

--- a/tools/spoiler_log_dump.py
+++ b/tools/spoiler_log_dump.py
@@ -3,10 +3,14 @@ import argparse
 import io
 import os
 import pickle
+import sys
+
+from typing import Optional
+
 import psycopg2
 import sqlite3
+
 from sqlite3 import Error
-import sys
 
 # Add the randomizer to the system path here.
 # Use the path within the web generator container.
@@ -15,7 +19,7 @@ sys.path.append('/home/ctjot/web/jetsoftime/sourcefiles')
 import randomizer
 
 
-def create_connection() -> sqlite3.Connection:
+def create_connection() -> Optional[sqlite3.Connection]:
     """
     Get a connection to the ctjot database.
 


### PR DESCRIPTION
This is follow-on work from https://github.com/Anguirel86/ctjot_web_generator/pull/20 requiring changes from https://github.com/Pseudoarc/jetsoftime/pull/23 and https://github.com/coffeemancy/jetsoftime/pull/5 to be merged into `jetsoftime` code base.

This PR currently includes a squash commit, so better to [compare to diffs](https://github.com/coffeemancy/ctjot_web_generator/compare/1e9d2fa6ee6aee9a0724ab8d7b3f60cafd8c2244..plus/presets).

This PR builds on other work to fully move the web UI to using JSON as the handoff from client-side JS to backend python for creating seeds. It loads all values in the UI into a hidden JSON field as a "preset" and passes along. It also allows a user to upload a custom preset and use that as well. Additionally users may take current settings and export as a preset JSON download.